### PR TITLE
PHP 8.1 return type required

### DIFF
--- a/lib/APITudeTransfer/AvailabilityApi.php
+++ b/lib/APITudeTransfer/AvailabilityApi.php
@@ -81,7 +81,7 @@ class AvailabilityApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function getConfig(): Configuration
     {
         return $this->config;
     }
@@ -105,9 +105,9 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return \Swagger\Client\Model\AvailabilityResponse
      */
-    public function availability($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants)
+    public function availability($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants): \Swagger\Client\Model\AvailabilityResponse
     {
-        list($response) = $this->availabilityWithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants);
+        [$response] = $this->availabilityWithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants);
         return $response;
     }
 
@@ -130,7 +130,7 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return array of \Swagger\Client\Model\AvailabilityResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function availabilityWithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants)
+    public function availabilityWithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants): array
     {
         $returnType = '\Swagger\Client\Model\AvailabilityResponse';
         $request = $this->availabilityRequest($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants);
@@ -236,7 +236,7 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function availabilityAsync($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants)
+    public function availabilityAsync($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->availabilityAsyncWithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants)
             ->then(
@@ -264,7 +264,7 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function availabilityAsyncWithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants)
+    public function availabilityAsyncWithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\Swagger\Client\Model\AvailabilityResponse';
         $request = $this->availabilityRequest($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants);
@@ -322,7 +322,7 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function availabilityRequest($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants)
+    protected function availabilityRequest($language, $from_type, $from_code, $to_type, $to_code, $outbound, $adults, $children, $infants): Request
     {
         // verify the required parameter 'language' is set
         if ($language === null || (is_array($language) && count($language) === 0)) {
@@ -549,9 +549,9 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return \Swagger\Client\Model\AvailabilityResponse
      */
-    public function availability1($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants)
+    public function availability1($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants): \Swagger\Client\Model\AvailabilityResponse
     {
-        list($response) = $this->availability1WithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants);
+        [$response] = $this->availability1WithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants);
         return $response;
     }
 
@@ -575,7 +575,7 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return array of \Swagger\Client\Model\AvailabilityResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function availability1WithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants)
+    public function availability1WithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants): array
     {
         $returnType = '\Swagger\Client\Model\AvailabilityResponse';
         $request = $this->availability1Request($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants);
@@ -682,7 +682,7 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function availability1Async($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants)
+    public function availability1Async($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->availability1AsyncWithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants)
             ->then(
@@ -711,7 +711,7 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function availability1AsyncWithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants)
+    public function availability1AsyncWithHttpInfo($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\Swagger\Client\Model\AvailabilityResponse';
         $request = $this->availability1Request($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants);
@@ -770,7 +770,7 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function availability1Request($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants)
+    protected function availability1Request($language, $from_type, $from_code, $to_type, $to_code, $outbound, $inbound, $adults, $children, $infants): Request
     {
         // verify the required parameter 'language' is set
         if ($language === null || (is_array($language) && count($language) === 0)) {
@@ -1010,9 +1010,9 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return \Swagger\Client\Model\AvailabilityResponse
      */
-    public function availability2($body, $language, $adults, $children, $infants, $vehicle = null, $type = null, $category = null, $allow_partial_results = 'true')
+    public function availability2($body, $language, $adults, $children, $infants, $vehicle = null, $type = null, $category = null, $allow_partial_results = 'true'): \Swagger\Client\Model\AvailabilityResponse
     {
-        list($response) = $this->availability2WithHttpInfo($body, $language, $adults, $children, $infants, $vehicle, $type, $category, $allow_partial_results);
+        [$response] = $this->availability2WithHttpInfo($body, $language, $adults, $children, $infants, $vehicle, $type, $category, $allow_partial_results);
         return $response;
     }
 
@@ -1035,7 +1035,7 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return array of \Swagger\Client\Model\AvailabilityResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function availability2WithHttpInfo($body, $language, $adults, $children, $infants, $vehicle = null, $type = null, $category = null, $allow_partial_results = 'true')
+    public function availability2WithHttpInfo($body, $language, $adults, $children, $infants, $vehicle = null, $type = null, $category = null, $allow_partial_results = 'true'): array
     {
         $returnType = '\Swagger\Client\Model\AvailabilityResponse';
         $request = $this->availability2Request($body, $language, $adults, $children, $infants, $vehicle, $type, $category, $allow_partial_results);
@@ -1141,7 +1141,7 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function availability2Async($body, $language, $adults, $children, $infants, $vehicle = null, $type = null, $category = null, $allow_partial_results = 'true')
+    public function availability2Async($body, $language, $adults, $children, $infants, $vehicle = null, $type = null, $category = null, $allow_partial_results = 'true'): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->availability2AsyncWithHttpInfo($body, $language, $adults, $children, $infants, $vehicle, $type, $category, $allow_partial_results)
             ->then(
@@ -1169,7 +1169,7 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function availability2AsyncWithHttpInfo($body, $language, $adults, $children, $infants, $vehicle = null, $type = null, $category = null, $allow_partial_results = 'true')
+    public function availability2AsyncWithHttpInfo($body, $language, $adults, $children, $infants, $vehicle = null, $type = null, $category = null, $allow_partial_results = 'true'): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\Swagger\Client\Model\AvailabilityResponse';
         $request = $this->availability2Request($body, $language, $adults, $children, $infants, $vehicle, $type, $category, $allow_partial_results);
@@ -1227,7 +1227,7 @@ class AvailabilityApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function availability2Request($body, $language, $adults, $children, $infants, $vehicle = null, $type = null, $category = null, $allow_partial_results = 'true')
+    protected function availability2Request($body, $language, $adults, $children, $infants, $vehicle = null, $type = null, $category = null, $allow_partial_results = 'true'): Request
     {
         // verify the required parameter 'body' is set
         if ($body === null || (is_array($body) && count($body) === 0)) {
@@ -1395,7 +1395,7 @@ class AvailabilityApi
      * @throws \RuntimeException on file opening failure
      * @return array of http client options
      */
-    protected function createHttpClientOption()
+    protected function createHttpClientOption(): array
     {
         $options = [];
         if ($this->config->getDebug()) {

--- a/lib/APITudeTransfer/BookingApi.php
+++ b/lib/APITudeTransfer/BookingApi.php
@@ -81,7 +81,7 @@ class BookingApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function getConfig(): Configuration
     {
         return $this->config;
     }
@@ -99,9 +99,9 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \Swagger\Client\Model\BookingResponse
      */
-    public function booking($language, $reference, $simulation = 'false')
+    public function booking($language, $reference, $simulation = 'false'): \Swagger\Client\Model\BookingResponse
     {
-        list($response) = $this->bookingWithHttpInfo($language, $reference, $simulation);
+        [$response] = $this->bookingWithHttpInfo($language, $reference, $simulation);
         return $response;
     }
 
@@ -118,7 +118,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return array of \Swagger\Client\Model\BookingResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function bookingWithHttpInfo($language, $reference, $simulation = 'false')
+    public function bookingWithHttpInfo($language, $reference, $simulation = 'false'):array
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->bookingRequest($language, $reference, $simulation);
@@ -202,7 +202,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function bookingAsync($language, $reference, $simulation = 'false')
+    public function bookingAsync($language, $reference, $simulation = 'false'):\GuzzleHttp\Promise\PromiseInterface
     {
         return $this->bookingAsyncWithHttpInfo($language, $reference, $simulation)
             ->then(
@@ -224,7 +224,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function bookingAsyncWithHttpInfo($language, $reference, $simulation = 'false')
+    public function bookingAsyncWithHttpInfo($language, $reference, $simulation = 'false'):\GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->bookingRequest($language, $reference, $simulation);
@@ -276,7 +276,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function bookingRequest($language, $reference, $simulation = 'false')
+    protected function bookingRequest($language, $reference, $simulation = 'false'):Request
     {
         // verify the required parameter 'language' is set
         if ($language === null || (is_array($language) && count($language) === 0)) {
@@ -402,9 +402,9 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \Swagger\Client\Model\BookingResponse
      */
-    public function booking1($language, $reference, $simulation = 'false')
+    public function booking1($language, $reference, $simulation = 'false'):\Swagger\Client\Model\BookingResponse
     {
-        list($response) = $this->booking1WithHttpInfo($language, $reference, $simulation);
+        [$response] = $this->booking1WithHttpInfo($language, $reference, $simulation);
         return $response;
     }
 
@@ -421,7 +421,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return array of \Swagger\Client\Model\BookingResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function booking1WithHttpInfo($language, $reference, $simulation = 'false')
+    public function booking1WithHttpInfo($language, $reference, $simulation = 'false'):array
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking1Request($language, $reference, $simulation);
@@ -505,7 +505,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking1Async($language, $reference, $simulation = 'false')
+    public function booking1Async($language, $reference, $simulation = 'false'):\GuzzleHttp\Promise\PromiseInterface
     {
         return $this->booking1AsyncWithHttpInfo($language, $reference, $simulation)
             ->then(
@@ -527,7 +527,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking1AsyncWithHttpInfo($language, $reference, $simulation = 'false')
+    public function booking1AsyncWithHttpInfo($language, $reference, $simulation = 'false'):\GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking1Request($language, $reference, $simulation);
@@ -579,7 +579,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function booking1Request($language, $reference, $simulation = 'false')
+    protected function booking1Request($language, $reference, $simulation = 'false'):Request
     {
         // verify the required parameter 'language' is set
         if ($language === null || (is_array($language) && count($language) === 0)) {
@@ -704,9 +704,9 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \Swagger\Client\Model\BookingResponse
      */
-    public function booking2($body, $x_platform_id = null)
+    public function booking2($body, $x_platform_id = null):\Swagger\Client\Model\BookingResponse
     {
-        list($response) = $this->booking2WithHttpInfo($body, $x_platform_id);
+        [$response] = $this->booking2WithHttpInfo($body, $x_platform_id);
         return $response;
     }
 
@@ -722,7 +722,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return array of \Swagger\Client\Model\BookingResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function booking2WithHttpInfo($body, $x_platform_id = null)
+    public function booking2WithHttpInfo($body, $x_platform_id = null):array
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking2Request($body, $x_platform_id);
@@ -805,7 +805,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking2Async($body, $x_platform_id = null)
+    public function booking2Async($body, $x_platform_id = null):\GuzzleHttp\Promise\PromiseInterface
     {
         return $this->booking2AsyncWithHttpInfo($body, $x_platform_id)
             ->then(
@@ -826,7 +826,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking2AsyncWithHttpInfo($body, $x_platform_id = null)
+    public function booking2AsyncWithHttpInfo($body, $x_platform_id = null):\GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking2Request($body, $x_platform_id);
@@ -877,7 +877,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function booking2Request($body, $x_platform_id = null)
+    protected function booking2Request($body, $x_platform_id = null):Request
     {
         // verify the required parameter 'body' is set
         if ($body === null || (is_array($body) && count($body) === 0)) {
@@ -983,9 +983,9 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \Swagger\Client\Model\BookingResponse
      */
-    public function booking3($body, $x_platform_id = null)
+    public function booking3($body, $x_platform_id = null):\Swagger\Client\Model\BookingResponse
     {
-        list($response) = $this->booking3WithHttpInfo($body, $x_platform_id);
+        [$response] = $this->booking3WithHttpInfo($body, $x_platform_id);
         return $response;
     }
 
@@ -1001,7 +1001,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return array of \Swagger\Client\Model\BookingResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function booking3WithHttpInfo($body, $x_platform_id = null)
+    public function booking3WithHttpInfo($body, $x_platform_id = null):array
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking3Request($body, $x_platform_id);
@@ -1084,7 +1084,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking3Async($body, $x_platform_id = null)
+    public function booking3Async($body, $x_platform_id = null):\GuzzleHttp\Promise\PromiseInterface
     {
         return $this->booking3AsyncWithHttpInfo($body, $x_platform_id)
             ->then(
@@ -1105,7 +1105,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking3AsyncWithHttpInfo($body, $x_platform_id = null)
+    public function booking3AsyncWithHttpInfo($body, $x_platform_id = null):\GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking3Request($body, $x_platform_id);
@@ -1156,7 +1156,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function booking3Request($body, $x_platform_id = null)
+    protected function booking3Request($body, $x_platform_id = null):Request
     {
         // verify the required parameter 'body' is set
         if ($body === null || (is_array($body) && count($body) === 0)) {
@@ -1262,9 +1262,9 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \Swagger\Client\Model\BookingResponse
      */
-    public function booking4($language, $reference)
+    public function booking4($language, $reference):\Swagger\Client\Model\BookingResponse
     {
-        list($response) = $this->booking4WithHttpInfo($language, $reference);
+        [$response] = $this->booking4WithHttpInfo($language, $reference);
         return $response;
     }
 
@@ -1280,7 +1280,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return array of \Swagger\Client\Model\BookingResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function booking4WithHttpInfo($language, $reference)
+    public function booking4WithHttpInfo($language, $reference):array
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking4Request($language, $reference);
@@ -1379,7 +1379,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking4Async($language, $reference)
+    public function booking4Async($language, $reference):\GuzzleHttp\Promise\PromiseInterface
     {
         return $this->booking4AsyncWithHttpInfo($language, $reference)
             ->then(
@@ -1400,7 +1400,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking4AsyncWithHttpInfo($language, $reference)
+    public function booking4AsyncWithHttpInfo($language, $reference):\GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking4Request($language, $reference);
@@ -1451,7 +1451,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function booking4Request($language, $reference)
+    protected function booking4Request($language, $reference):Request
     {
         // verify the required parameter 'language' is set
         if ($language === null || (is_array($language) && count($language) === 0)) {
@@ -1572,9 +1572,9 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \Swagger\Client\Model\BookingResponse
      */
-    public function booking5($language, $reference)
+    public function booking5($language, $reference):\Swagger\Client\Model\BookingResponse
     {
-        list($response) = $this->booking5WithHttpInfo($language, $reference);
+        [$response] = $this->booking5WithHttpInfo($language, $reference);
         return $response;
     }
 
@@ -1590,7 +1590,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return array of \Swagger\Client\Model\BookingResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function booking5WithHttpInfo($language, $reference)
+    public function booking5WithHttpInfo($language, $reference):array
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking5Request($language, $reference);
@@ -1689,7 +1689,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking5Async($language, $reference)
+    public function booking5Async($language, $reference):\GuzzleHttp\Promise\PromiseInterface
     {
         return $this->booking5AsyncWithHttpInfo($language, $reference)
             ->then(
@@ -1710,7 +1710,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking5AsyncWithHttpInfo($language, $reference)
+    public function booking5AsyncWithHttpInfo($language, $reference):\GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking5Request($language, $reference);
@@ -1761,7 +1761,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function booking5Request($language, $reference)
+    protected function booking5Request($language, $reference):Request
     {
         // verify the required parameter 'language' is set
         if ($language === null || (is_array($language) && count($language) === 0)) {
@@ -1888,9 +1888,9 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \Swagger\Client\Model\BookingListResponse
      */
-    public function booking6($language, $from_date = null, $to_date = null, $date_type = null, $offset = '1', $limit = '1', $agency = null, $surname = null)
+    public function booking6($language, $from_date = null, $to_date = null, $date_type = null, $offset = '1', $limit = '1', $agency = null, $surname = null):\Swagger\Client\Model\BookingListResponse
     {
-        list($response) = $this->booking6WithHttpInfo($language, $from_date, $to_date, $date_type, $offset, $limit, $agency, $surname);
+        [$response] = $this->booking6WithHttpInfo($language, $from_date, $to_date, $date_type, $offset, $limit, $agency, $surname);
         return $response;
     }
 
@@ -1912,7 +1912,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return array of \Swagger\Client\Model\BookingListResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function booking6WithHttpInfo($language, $from_date = null, $to_date = null, $date_type = null, $offset = '1', $limit = '1', $agency = null, $surname = null)
+    public function booking6WithHttpInfo($language, $from_date = null, $to_date = null, $date_type = null, $offset = '1', $limit = '1', $agency = null, $surname = null):array
     {
         $returnType = '\Swagger\Client\Model\BookingListResponse';
         $request = $this->booking6Request($language, $from_date, $to_date, $date_type, $offset, $limit, $agency, $surname);
@@ -2017,7 +2017,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking6Async($language, $from_date = null, $to_date = null, $date_type = null, $offset = '1', $limit = '1', $agency = null, $surname = null)
+    public function booking6Async($language, $from_date = null, $to_date = null, $date_type = null, $offset = '1', $limit = '1', $agency = null, $surname = null):\GuzzleHttp\Promise\PromiseInterface
     {
         return $this->booking6AsyncWithHttpInfo($language, $from_date, $to_date, $date_type, $offset, $limit, $agency, $surname)
             ->then(
@@ -2044,7 +2044,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking6AsyncWithHttpInfo($language, $from_date = null, $to_date = null, $date_type = null, $offset = '1', $limit = '1', $agency = null, $surname = null)
+    public function booking6AsyncWithHttpInfo($language, $from_date = null, $to_date = null, $date_type = null, $offset = '1', $limit = '1', $agency = null, $surname = null):\GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\Swagger\Client\Model\BookingListResponse';
         $request = $this->booking6Request($language, $from_date, $to_date, $date_type, $offset, $limit, $agency, $surname);
@@ -2101,7 +2101,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function booking6Request($language, $from_date = null, $to_date = null, $date_type = null, $offset = '1', $limit = '1', $agency = null, $surname = null)
+    protected function booking6Request($language, $from_date = null, $to_date = null, $date_type = null, $offset = '1', $limit = '1', $agency = null, $surname = null):Request
     {
         // verify the required parameter 'language' is set
         if ($language === null || (is_array($language) && count($language) === 0)) {
@@ -2238,9 +2238,9 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \Swagger\Client\Model\BookingResponse
      */
-    public function booking7($language, $reference, $id, $simulation = 'false')
+    public function booking7($language, $reference, $id, $simulation = 'false'):\Swagger\Client\Model\BookingResponse
     {
-        list($response) = $this->booking7WithHttpInfo($language, $reference, $id, $simulation);
+        [$response] = $this->booking7WithHttpInfo($language, $reference, $id, $simulation);
         return $response;
     }
 
@@ -2258,7 +2258,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return array of \Swagger\Client\Model\BookingResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function booking7WithHttpInfo($language, $reference, $id, $simulation = 'false')
+    public function booking7WithHttpInfo($language, $reference, $id, $simulation = 'false'):array
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking7Request($language, $reference, $id, $simulation);
@@ -2343,7 +2343,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking7Async($language, $reference, $id, $simulation = 'false')
+    public function booking7Async($language, $reference, $id, $simulation = 'false'):\GuzzleHttp\Promise\PromiseInterface
     {
         return $this->booking7AsyncWithHttpInfo($language, $reference, $id, $simulation)
             ->then(
@@ -2366,7 +2366,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking7AsyncWithHttpInfo($language, $reference, $id, $simulation = 'false')
+    public function booking7AsyncWithHttpInfo($language, $reference, $id, $simulation = 'false'):\GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking7Request($language, $reference, $id, $simulation);
@@ -2419,7 +2419,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function booking7Request($language, $reference, $id, $simulation = 'false')
+    protected function booking7Request($language, $reference, $id, $simulation = 'false'):Request
     {
         // verify the required parameter 'language' is set
         if ($language === null || (is_array($language) && count($language) === 0)) {
@@ -2560,9 +2560,9 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \Swagger\Client\Model\BookingResponse
      */
-    public function booking8($language, $reference, $id, $simulation = 'false')
+    public function booking8($language, $reference, $id, $simulation = 'false'):\Swagger\Client\Model\BookingResponse
     {
-        list($response) = $this->booking8WithHttpInfo($language, $reference, $id, $simulation);
+        [$response] = $this->booking8WithHttpInfo($language, $reference, $id, $simulation);
         return $response;
     }
 
@@ -2580,7 +2580,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return array of \Swagger\Client\Model\BookingResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function booking8WithHttpInfo($language, $reference, $id, $simulation = 'false')
+    public function booking8WithHttpInfo($language, $reference, $id, $simulation = 'false'):array
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking8Request($language, $reference, $id, $simulation);
@@ -2665,7 +2665,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking8Async($language, $reference, $id, $simulation = 'false')
+    public function booking8Async($language, $reference, $id, $simulation = 'false'):\GuzzleHttp\Promise\PromiseInterface
     {
         return $this->booking8AsyncWithHttpInfo($language, $reference, $id, $simulation)
             ->then(
@@ -2688,7 +2688,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function booking8AsyncWithHttpInfo($language, $reference, $id, $simulation = 'false')
+    public function booking8AsyncWithHttpInfo($language, $reference, $id, $simulation = 'false'):\GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\Swagger\Client\Model\BookingResponse';
         $request = $this->booking8Request($language, $reference, $id, $simulation);
@@ -2741,7 +2741,7 @@ class BookingApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function booking8Request($language, $reference, $id, $simulation = 'false')
+    protected function booking8Request($language, $reference, $id, $simulation = 'false'):Request
     {
         // verify the required parameter 'language' is set
         if ($language === null || (is_array($language) && count($language) === 0)) {
@@ -2874,7 +2874,7 @@ class BookingApi
      * @throws \RuntimeException on file opening failure
      * @return array of http client options
      */
-    protected function createHttpClientOption()
+    protected function createHttpClientOption():array
     {
         $options = [];
         if ($this->config->getDebug()) {

--- a/lib/ApiException.php
+++ b/lib/ApiException.php
@@ -81,7 +81,7 @@ class ApiException extends Exception
      *
      * @return string[]|null HTTP response header
      */
-    public function getResponseHeaders()
+    public function getResponseHeaders(): ?array
     {
         return $this->responseHeaders;
     }
@@ -91,7 +91,7 @@ class ApiException extends Exception
      *
      * @return mixed HTTP body of the server response either as \stdClass or string
      */
-    public function getResponseBody()
+    public function getResponseBody(): mixed
     {
         return $this->responseBody;
     }
@@ -103,7 +103,7 @@ class ApiException extends Exception
      *
      * @return void
      */
-    public function setResponseObject($obj)
+    public function setResponseObject($obj): void
     {
         $this->responseObject = $obj;
     }
@@ -113,7 +113,7 @@ class ApiException extends Exception
      *
      * @return mixed the deserialized response object
      */
-    public function getResponseObject()
+    public function getResponseObject(): mixed
     {
         return $this->responseObject;
     }

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -126,7 +126,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setApiKey($apiKeyIdentifier, $key)
+    public function setApiKey($apiKeyIdentifier, $key): static
     {
         $this->apiKeys[$apiKeyIdentifier] = $key;
         return $this;
@@ -139,7 +139,7 @@ class Configuration
      *
      * @return string API key or token
      */
-    public function getApiKey($apiKeyIdentifier)
+    public function getApiKey($apiKeyIdentifier): ?string
     {
         return isset($this->apiKeys[$apiKeyIdentifier]) ? $this->apiKeys[$apiKeyIdentifier] : null;
     }
@@ -152,7 +152,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setApiKeyPrefix($apiKeyIdentifier, $prefix)
+    public function setApiKeyPrefix($apiKeyIdentifier, $prefix): static
     {
         $this->apiKeyPrefixes[$apiKeyIdentifier] = $prefix;
         return $this;
@@ -165,7 +165,7 @@ class Configuration
      *
      * @return string
      */
-    public function getApiKeyPrefix($apiKeyIdentifier)
+    public function getApiKeyPrefix($apiKeyIdentifier): ?string
     {
         return isset($this->apiKeyPrefixes[$apiKeyIdentifier]) ? $this->apiKeyPrefixes[$apiKeyIdentifier] : null;
     }
@@ -177,7 +177,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setAccessToken($accessToken)
+    public function setAccessToken($accessToken): static
     {
         $this->accessToken = $accessToken;
         return $this;
@@ -188,7 +188,7 @@ class Configuration
      *
      * @return string Access token for OAuth
      */
-    public function getAccessToken()
+    public function getAccessToken(): string
     {
         return $this->accessToken;
     }
@@ -200,7 +200,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setUsername($username)
+    public function setUsername($username): static
     {
         $this->username = $username;
         return $this;
@@ -211,7 +211,7 @@ class Configuration
      *
      * @return string Username for HTTP basic authentication
      */
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->username;
     }
@@ -223,7 +223,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setPassword($password)
+    public function setPassword($password): static
     {
         $this->password = $password;
         return $this;
@@ -234,7 +234,7 @@ class Configuration
      *
      * @return string Password for HTTP basic authentication
      */
-    public function getPassword()
+    public function getPassword(): string
     {
         return $this->password;
     }
@@ -246,7 +246,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setHost($host)
+    public function setHost($host): static
     {
         $this->host = $host;
         return $this;
@@ -257,7 +257,7 @@ class Configuration
      *
      * @return string Host
      */
-    public function getHost()
+    public function getHost(): string
     {
         return $this->host;
     }
@@ -270,7 +270,7 @@ class Configuration
      * @throws \InvalidArgumentException
      * @return $this
      */
-    public function setUserAgent($userAgent)
+    public function setUserAgent($userAgent): static
     {
         if (!is_string($userAgent)) {
             throw new \InvalidArgumentException('User-agent must be a string.');
@@ -285,7 +285,7 @@ class Configuration
      *
      * @return string user agent
      */
-    public function getUserAgent()
+    public function getUserAgent(): string
     {
         return $this->userAgent;
     }
@@ -297,7 +297,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setDebug($debug)
+    public function setDebug($debug): static
     {
         $this->debug = $debug;
         return $this;
@@ -308,7 +308,7 @@ class Configuration
      *
      * @return bool
      */
-    public function getDebug()
+    public function getDebug(): bool
     {
         return $this->debug;
     }
@@ -320,7 +320,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setDebugFile($debugFile)
+    public function setDebugFile($debugFile): static
     {
         $this->debugFile = $debugFile;
         return $this;
@@ -331,7 +331,7 @@ class Configuration
      *
      * @return string
      */
-    public function getDebugFile()
+    public function getDebugFile(): string
     {
         return $this->debugFile;
     }
@@ -343,7 +343,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setTempFolderPath($tempFolderPath)
+    public function setTempFolderPath($tempFolderPath): static
     {
         $this->tempFolderPath = $tempFolderPath;
         return $this;
@@ -354,7 +354,7 @@ class Configuration
      *
      * @return string Temp folder path
      */
-    public function getTempFolderPath()
+    public function getTempFolderPath(): string
     {
         return $this->tempFolderPath;
     }
@@ -364,7 +364,7 @@ class Configuration
      *
      * @return Configuration
      */
-    public static function getDefaultConfiguration()
+    public static function getDefaultConfiguration(): Configuration
     {
         if (self::$defaultConfiguration === null) {
             self::$defaultConfiguration = new Configuration();
@@ -380,7 +380,7 @@ class Configuration
      *
      * @return void
      */
-    public static function setDefaultConfiguration(Configuration $config)
+    public static function setDefaultConfiguration(Configuration $config): void
     {
         self::$defaultConfiguration = $config;
     }
@@ -390,7 +390,7 @@ class Configuration
      *
      * @return string The report for debugging
      */
-    public static function toDebugReport()
+    public static function toDebugReport(): string
     {
         $report  = 'PHP SDK (Swagger\Client) Debug Report:' . PHP_EOL;
         $report .= '    OS: ' . php_uname() . PHP_EOL;
@@ -408,7 +408,7 @@ class Configuration
      *
      * @return string API key with the prefix
      */
-    public function getApiKeyWithPrefix($apiKeyIdentifier)
+    public function getApiKeyWithPrefix($apiKeyIdentifier): ?string
     {
         $prefix = $this->getApiKeyPrefix($apiKeyIdentifier);
         $apiKey = $this->getApiKey($apiKeyIdentifier);

--- a/lib/HeaderSelector.php
+++ b/lib/HeaderSelector.php
@@ -45,7 +45,7 @@ class HeaderSelector
      * @param string[] $contentTypes
      * @return array
      */
-    public function selectHeaders($accept, $contentTypes)
+    public function selectHeaders($accept, $contentTypes): array
     {
         $headers = [];
 
@@ -62,7 +62,7 @@ class HeaderSelector
      * @param string[] $accept
      * @return array
      */
-    public function selectHeadersForMultipart($accept)
+    public function selectHeadersForMultipart($accept): array
     {
         $headers = $this->selectHeaders($accept, []);
 
@@ -77,7 +77,7 @@ class HeaderSelector
      *
      * @return string Accept (e.g. application/json)
      */
-    private function selectAcceptHeader($accept)
+    private function selectAcceptHeader($accept): ?string
     {
         if (count($accept) === 0 || (count($accept) === 1 && $accept[0] === '')) {
             return null;
@@ -95,7 +95,7 @@ class HeaderSelector
      *
      * @return string Content-Type (e.g. application/json)
      */
-    private function selectContentTypeHeader($contentType)
+    private function selectContentTypeHeader($contentType): string
     {
         if (count($contentType) === 0 || (count($contentType) === 1 && $contentType[0] === '')) {
             return 'application/json';

--- a/lib/Model/AvailabilityRequest.php
+++ b/lib/Model/AvailabilityRequest.php
@@ -82,7 +82,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -92,7 +92,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -143,7 +143,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -153,7 +153,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -163,7 +163,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -173,7 +173,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -208,7 +208,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -239,7 +239,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -250,7 +250,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferDateTime
      */
-    public function getComeBack()
+    public function getComeBack(): TransferDateTime
     {
         return $this->container['come_back'];
     }
@@ -262,7 +262,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setComeBack($come_back)
+    public function setComeBack($come_back): static
     {
         $this->container['come_back'] = $come_back;
 
@@ -274,7 +274,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferDateTime
      */
-    public function getDeparture()
+    public function getDeparture(): TransferDateTime
     {
         return $this->container['departure'];
     }
@@ -286,7 +286,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDeparture($departure)
+    public function setDeparture($departure): static
     {
         $this->container['departure'] = $departure;
 
@@ -298,7 +298,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferPoint
      */
-    public function getFrom()
+    public function getFrom(): TransferPoint
     {
         return $this->container['from'];
     }
@@ -310,7 +310,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setFrom($from)
+    public function setFrom($from): static
     {
         $this->container['from'] = $from;
 
@@ -322,7 +322,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getLanguage()
+    public function getLanguage(): string
     {
         return $this->container['language'];
     }
@@ -334,7 +334,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setLanguage($language)
+    public function setLanguage($language): static
     {
         $this->container['language'] = $language;
 
@@ -346,7 +346,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Occupancy
      */
-    public function getOccupancy()
+    public function getOccupancy(): Occupancy
     {
         return $this->container['occupancy'];
     }
@@ -358,7 +358,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setOccupancy($occupancy)
+    public function setOccupancy($occupancy): static
     {
         $this->container['occupancy'] = $occupancy;
 
@@ -370,7 +370,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferPoint
      */
-    public function getTo()
+    public function getTo(): TransferPoint
     {
         return $this->container['to'];
     }
@@ -382,7 +382,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTo($to)
+    public function setTo($to): static
     {
         $this->container['to'] = $to;
 
@@ -395,7 +395,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -407,7 +407,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -420,7 +420,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -436,7 +436,7 @@ class AvailabilityRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/AvailabilityResponse.php
+++ b/lib/Model/AvailabilityResponse.php
@@ -74,7 +74,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -84,7 +84,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -123,7 +123,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -133,7 +133,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -143,7 +143,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -153,7 +153,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -184,7 +184,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -200,7 +200,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -211,7 +211,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\AvailabilityRequest
      */
-    public function getSearch()
+    public function getSearch(): AvailabilityRequest
     {
         return $this->container['search'];
     }
@@ -223,7 +223,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setSearch($search)
+    public function setSearch($search): static
     {
         $this->container['search'] = $search;
 
@@ -235,7 +235,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferServiceAvail[]
      */
-    public function getServices()
+    public function getServices(): array
     {
         return $this->container['services'];
     }
@@ -247,7 +247,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setServices($services)
+    public function setServices($services): static
     {
         $this->container['services'] = $services;
 
@@ -260,7 +260,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -272,7 +272,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -285,7 +285,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -301,7 +301,7 @@ class AvailabilityResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/AvailabilityRoutesRequest.php
+++ b/lib/Model/AvailabilityRoutesRequest.php
@@ -82,7 +82,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -92,7 +92,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -143,7 +143,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -153,7 +153,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -163,7 +163,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -173,7 +173,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -208,7 +208,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -239,7 +239,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -250,7 +250,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getCategory()
+    public function getCategory(): string
     {
         return $this->container['category'];
     }
@@ -262,7 +262,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCategory($category)
+    public function setCategory($category): static
     {
         $this->container['category'] = $category;
 
@@ -274,7 +274,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getLanguage()
+    public function getLanguage(): string
     {
         return $this->container['language'];
     }
@@ -286,7 +286,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setLanguage($language)
+    public function setLanguage($language): static
     {
         $this->container['language'] = $language;
 
@@ -298,7 +298,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Occupancy
      */
-    public function getOccupancy()
+    public function getOccupancy(): Occupancy
     {
         return $this->container['occupancy'];
     }
@@ -310,7 +310,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setOccupancy($occupancy)
+    public function setOccupancy($occupancy): static
     {
         $this->container['occupancy'] = $occupancy;
 
@@ -322,7 +322,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\RouteRequestDTO[]
      */
-    public function getRoutes()
+    public function getRoutes(): array
     {
         return $this->container['routes'];
     }
@@ -334,7 +334,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setRoutes($routes)
+    public function setRoutes($routes): static
     {
         $this->container['routes'] = $routes;
 
@@ -346,7 +346,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->container['type'];
     }
@@ -358,7 +358,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $this->container['type'] = $type;
 
@@ -370,7 +370,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getVehicle()
+    public function getVehicle(): string
     {
         return $this->container['vehicle'];
     }
@@ -382,7 +382,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setVehicle($vehicle)
+    public function setVehicle($vehicle): static
     {
         $this->container['vehicle'] = $vehicle;
 
@@ -395,7 +395,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -407,7 +407,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -420,7 +420,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -436,7 +436,7 @@ class AvailabilityRoutesRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/AvailabilityRoutesResponse.php
+++ b/lib/Model/AvailabilityRoutesResponse.php
@@ -74,7 +74,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -84,7 +84,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -123,7 +123,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -133,7 +133,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -143,7 +143,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -153,7 +153,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -184,7 +184,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -200,7 +200,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -211,7 +211,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Route[]
      */
-    public function getRoutes()
+    public function getRoutes(): array
     {
         return $this->container['routes'];
     }
@@ -223,7 +223,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setRoutes($routes)
+    public function setRoutes($routes): static
     {
         $this->container['routes'] = $routes;
 
@@ -235,7 +235,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\AvailabilityRoutesRequest
      */
-    public function getSearch()
+    public function getSearch(): AvailabilityRoutesRequest
     {
         return $this->container['search'];
     }
@@ -247,7 +247,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setSearch($search)
+    public function setSearch($search): static
     {
         $this->container['search'] = $search;
 
@@ -260,7 +260,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -272,7 +272,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -285,7 +285,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -301,7 +301,7 @@ class AvailabilityRoutesResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/Booking.php
+++ b/lib/Model/Booking.php
@@ -102,7 +102,7 @@ class Booking implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -112,7 +112,7 @@ class Booking implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -193,7 +193,7 @@ class Booking implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -203,7 +203,7 @@ class Booking implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -213,7 +213,7 @@ class Booking implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -223,7 +223,7 @@ class Booking implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -237,7 +237,7 @@ const STATUS_MODIFIED = 'MODIFIED';
      *
      * @return string[]
      */
-    public function getStatusAllowableValues()
+    public function getStatusAllowableValues(): array
     {
         return [
             self::STATUS_CONFIRMED,
@@ -283,7 +283,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -340,7 +340,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -351,7 +351,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return string
      */
-    public function getBookingFileId()
+    public function getBookingFileId(): string
     {
         return $this->container['booking_file_id'];
     }
@@ -363,7 +363,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setBookingFileId($booking_file_id)
+    public function setBookingFileId($booking_file_id): static
     {
         $this->container['booking_file_id'] = $booking_file_id;
 
@@ -375,7 +375,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return string
      */
-    public function getClientReference()
+    public function getClientReference(): string
     {
         return $this->container['client_reference'];
     }
@@ -387,7 +387,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setClientReference($client_reference)
+    public function setClientReference($client_reference): static
     {
         $this->container['client_reference'] = $client_reference;
 
@@ -399,7 +399,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return string
      */
-    public function getCreationDate()
+    public function getCreationDate(): string
     {
         return $this->container['creation_date'];
     }
@@ -411,7 +411,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setCreationDate($creation_date)
+    public function setCreationDate($creation_date): static
     {
         $this->container['creation_date'] = $creation_date;
 
@@ -423,7 +423,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return string
      */
-    public function getCurrency()
+    public function getCurrency(): string
     {
         return $this->container['currency'];
     }
@@ -435,7 +435,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setCurrency($currency)
+    public function setCurrency($currency): static
     {
         $this->container['currency'] = $currency;
 
@@ -447,7 +447,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return \Swagger\Client\Model\Pax
      */
-    public function getHolder()
+    public function getHolder(): Pax
     {
         return $this->container['holder'];
     }
@@ -459,7 +459,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setHolder($holder)
+    public function setHolder($holder): static
     {
         $this->container['holder'] = $holder;
 
@@ -471,7 +471,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return \Swagger\Client\Model\InvoiceCompany
      */
-    public function getInvoiceCompany()
+    public function getInvoiceCompany(): InvoiceCompany
     {
         return $this->container['invoice_company'];
     }
@@ -483,7 +483,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setInvoiceCompany($invoice_company)
+    public function setInvoiceCompany($invoice_company): static
     {
         $this->container['invoice_company'] = $invoice_company;
 
@@ -495,7 +495,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return \Swagger\Client\Model\Link[]
      */
-    public function getLinks()
+    public function getLinks(): array
     {
         return $this->container['links'];
     }
@@ -507,7 +507,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setLinks($links)
+    public function setLinks($links): static
     {
         $this->container['links'] = $links;
 
@@ -519,7 +519,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return \Swagger\Client\Model\ModificationsPolicies
      */
-    public function getModificationsPolicies()
+    public function getModificationsPolicies(): ModificationsPolicies
     {
         return $this->container['modifications_policies'];
     }
@@ -531,7 +531,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setModificationsPolicies($modifications_policies)
+    public function setModificationsPolicies($modifications_policies): static
     {
         $this->container['modifications_policies'] = $modifications_policies;
 
@@ -543,7 +543,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return float
      */
-    public function getPendingAmount()
+    public function getPendingAmount(): float
     {
         return $this->container['pending_amount'];
     }
@@ -555,7 +555,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setPendingAmount($pending_amount)
+    public function setPendingAmount($pending_amount): static
     {
         $this->container['pending_amount'] = $pending_amount;
 
@@ -567,7 +567,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return string
      */
-    public function getReference()
+    public function getReference(): string
     {
         return $this->container['reference'];
     }
@@ -579,7 +579,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setReference($reference)
+    public function setReference($reference): static
     {
         $this->container['reference'] = $reference;
 
@@ -591,7 +591,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return string
      */
-    public function getRemark()
+    public function getRemark(): string
     {
         return $this->container['remark'];
     }
@@ -603,7 +603,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setRemark($remark)
+    public function setRemark($remark): static
     {
         $this->container['remark'] = $remark;
 
@@ -615,7 +615,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return string
      */
-    public function getStatus()
+    public function getStatus(): string
     {
         return $this->container['status'];
     }
@@ -627,7 +627,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setStatus($status)
+    public function setStatus($status): static
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
@@ -648,7 +648,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return \Swagger\Client\Model\InvoiceCompany
      */
-    public function getSupplier()
+    public function getSupplier(): InvoiceCompany
     {
         return $this->container['supplier'];
     }
@@ -660,7 +660,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setSupplier($supplier)
+    public function setSupplier($supplier): static
     {
         $this->container['supplier'] = $supplier;
 
@@ -672,7 +672,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return float
      */
-    public function getTotalAmount()
+    public function getTotalAmount(): float
     {
         return $this->container['total_amount'];
     }
@@ -684,7 +684,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setTotalAmount($total_amount)
+    public function setTotalAmount($total_amount): static
     {
         $this->container['total_amount'] = $total_amount;
 
@@ -696,7 +696,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return float
      */
-    public function getTotalNetAmount()
+    public function getTotalNetAmount(): float
     {
         return $this->container['total_net_amount'];
     }
@@ -708,7 +708,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setTotalNetAmount($total_net_amount)
+    public function setTotalNetAmount($total_net_amount): static
     {
         $this->container['total_net_amount'] = $total_net_amount;
 
@@ -720,7 +720,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return \Swagger\Client\Model\TransferServiceBookingCancel[]
      */
-    public function getTransfers()
+    public function getTransfers(): array
     {
         return $this->container['transfers'];
     }
@@ -732,7 +732,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return $this
      */
-    public function setTransfers($transfers)
+    public function setTransfers($transfers): static
     {
         $this->container['transfers'] = $transfers;
 
@@ -745,7 +745,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -757,7 +757,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -770,7 +770,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -786,7 +786,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/BookingListResponse.php
+++ b/lib/Model/BookingListResponse.php
@@ -72,7 +72,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -82,7 +82,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -118,7 +118,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -128,7 +128,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -138,7 +138,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -148,7 +148,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -178,7 +178,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -194,7 +194,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -205,7 +205,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Booking[]
      */
-    public function getBookings()
+    public function getBookings(): array
     {
         return $this->container['bookings'];
     }
@@ -217,7 +217,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setBookings($bookings)
+    public function setBookings($bookings): static
     {
         $this->container['bookings'] = $bookings;
 
@@ -230,7 +230,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -242,7 +242,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -255,7 +255,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -271,7 +271,7 @@ class BookingListResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/BookingResponse.php
+++ b/lib/Model/BookingResponse.php
@@ -72,7 +72,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -82,7 +82,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -118,7 +118,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -128,7 +128,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -138,7 +138,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -148,7 +148,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -178,7 +178,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -194,7 +194,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -205,7 +205,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Booking[]
      */
-    public function getBookings()
+    public function getBookings(): array
     {
         return $this->container['bookings'];
     }
@@ -217,7 +217,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setBookings($bookings)
+    public function setBookings($bookings): static
     {
         $this->container['bookings'] = $bookings;
 
@@ -230,7 +230,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -242,7 +242,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -255,7 +255,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -271,7 +271,7 @@ class BookingResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/CancellationPolicy.php
+++ b/lib/Model/CancellationPolicy.php
@@ -76,7 +76,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -86,7 +86,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -128,7 +128,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -138,7 +138,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -148,7 +148,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -158,7 +158,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -190,7 +190,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -212,7 +212,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -223,7 +223,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return float
      */
-    public function getAmount()
+    public function getAmount(): float
     {
         return $this->container['amount'];
     }
@@ -235,7 +235,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setAmount($amount)
+    public function setAmount($amount): static
     {
         $this->container['amount'] = $amount;
 
@@ -247,7 +247,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getCurrencyId()
+    public function getCurrencyId(): string
     {
         return $this->container['currency_id'];
     }
@@ -259,7 +259,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCurrencyId($currency_id)
+    public function setCurrencyId($currency_id): static
     {
         $this->container['currency_id'] = $currency_id;
 
@@ -271,7 +271,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getFrom()
+    public function getFrom(): string
     {
         return $this->container['from'];
     }
@@ -283,7 +283,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setFrom($from)
+    public function setFrom($from): static
     {
         $this->container['from'] = $from;
 
@@ -296,7 +296,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -308,7 +308,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -321,7 +321,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -337,7 +337,7 @@ class CancellationPolicy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/Category.php
+++ b/lib/Model/Category.php
@@ -74,7 +74,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -84,7 +84,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -123,7 +123,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -133,7 +133,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -143,7 +143,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -153,7 +153,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -184,7 +184,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -200,7 +200,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -211,7 +211,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->container['code'];
     }
@@ -223,7 +223,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCode($code)
+    public function setCode($code): static
     {
         $this->container['code'] = $code;
 
@@ -235,7 +235,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->container['name'];
     }
@@ -247,7 +247,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName($name): static
     {
         $this->container['name'] = $name;
 
@@ -260,7 +260,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -272,7 +272,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -285,7 +285,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -301,7 +301,7 @@ class Category implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/CheckPickup.php
+++ b/lib/Model/CheckPickup.php
@@ -76,7 +76,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -86,7 +86,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -128,7 +128,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -138,7 +138,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -148,7 +148,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -158,7 +158,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -190,7 +190,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -203,7 +203,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -214,7 +214,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return int
      */
-    public function getHoursBeforeConsulting()
+    public function getHoursBeforeConsulting(): int
     {
         return $this->container['hours_before_consulting'];
     }
@@ -226,7 +226,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setHoursBeforeConsulting($hours_before_consulting)
+    public function setHoursBeforeConsulting($hours_before_consulting): static
     {
         $this->container['hours_before_consulting'] = $hours_before_consulting;
 
@@ -238,7 +238,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return bool
      */
-    public function getMustCheckPickupTime()
+    public function getMustCheckPickupTime(): bool
     {
         return $this->container['must_check_pickup_time'];
     }
@@ -250,7 +250,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setMustCheckPickupTime($must_check_pickup_time)
+    public function setMustCheckPickupTime($must_check_pickup_time): static
     {
         $this->container['must_check_pickup_time'] = $must_check_pickup_time;
 
@@ -262,7 +262,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getUrl()
+    public function getUrl(): string
     {
         return $this->container['url'];
     }
@@ -274,7 +274,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setUrl($url)
+    public function setUrl($url): static
     {
         $this->container['url'] = $url;
 
@@ -287,7 +287,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -299,7 +299,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -312,7 +312,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -328,7 +328,7 @@ class CheckPickup implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/ConfirmPickupInformation.php
+++ b/lib/Model/ConfirmPickupInformation.php
@@ -80,7 +80,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -90,7 +90,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -138,7 +138,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -148,7 +148,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -158,7 +158,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -168,7 +168,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -202,7 +202,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -215,7 +215,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -226,7 +226,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getAddress()
+    public function getAddress(): string
     {
         return $this->container['address'];
     }
@@ -238,7 +238,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setAddress($address)
+    public function setAddress($address): static
     {
         $this->container['address'] = $address;
 
@@ -250,7 +250,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getCountry()
+    public function getCountry(): string
     {
         return $this->container['country'];
     }
@@ -262,7 +262,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCountry($country)
+    public function setCountry($country): static
     {
         $this->container['country'] = $country;
 
@@ -274,7 +274,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->container['name'];
     }
@@ -286,7 +286,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName($name): static
     {
         $this->container['name'] = $name;
 
@@ -298,7 +298,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getTown()
+    public function getTown(): string
     {
         return $this->container['town'];
     }
@@ -310,7 +310,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTown($town)
+    public function setTown($town): static
     {
         $this->container['town'] = $town;
 
@@ -322,7 +322,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getZip()
+    public function getZip(): string
     {
         return $this->container['zip'];
     }
@@ -334,7 +334,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setZip($zip)
+    public function setZip($zip): static
     {
         $this->container['zip'] = $zip;
 
@@ -347,7 +347,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -359,7 +359,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -372,7 +372,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -388,7 +388,7 @@ class ConfirmPickupInformation implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/ConfirmRequest.php
+++ b/lib/Model/ConfirmRequest.php
@@ -80,7 +80,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -90,7 +90,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -138,7 +138,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -148,7 +148,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -158,7 +158,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -168,7 +168,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -202,7 +202,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -224,7 +224,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -235,7 +235,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getClientReference()
+    public function getClientReference(): string
     {
         return $this->container['client_reference'];
     }
@@ -247,7 +247,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setClientReference($client_reference)
+    public function setClientReference($client_reference): static
     {
         $this->container['client_reference'] = $client_reference;
 
@@ -259,7 +259,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Pax
      */
-    public function getHolder()
+    public function getHolder(): Pax
     {
         return $this->container['holder'];
     }
@@ -271,7 +271,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setHolder($holder)
+    public function setHolder($holder): static
     {
         $this->container['holder'] = $holder;
 
@@ -283,7 +283,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getLanguage()
+    public function getLanguage(): string
     {
         return $this->container['language'];
     }
@@ -295,7 +295,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setLanguage($language)
+    public function setLanguage($language): static
     {
         $this->container['language'] = $language;
 
@@ -307,7 +307,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getRemark()
+    public function getRemark(): string
     {
         return $this->container['remark'];
     }
@@ -319,7 +319,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setRemark($remark)
+    public function setRemark($remark): static
     {
         $this->container['remark'] = $remark;
 
@@ -331,7 +331,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferConfirm[]
      */
-    public function getTransfers()
+    public function getTransfers(): array
     {
         return $this->container['transfers'];
     }
@@ -343,7 +343,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTransfers($transfers)
+    public function setTransfers($transfers): static
     {
         $this->container['transfers'] = $transfers;
 
@@ -356,7 +356,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -368,7 +368,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -381,7 +381,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -397,7 +397,7 @@ class ConfirmRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/Detail.php
+++ b/lib/Model/Detail.php
@@ -82,7 +82,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -92,7 +92,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -143,7 +143,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -153,7 +153,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -163,7 +163,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -173,7 +173,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -208,7 +208,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -221,7 +221,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -232,7 +232,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getArrivalFlightNumber()
+    public function getArrivalFlightNumber(): string
     {
         return $this->container['arrival_flight_number'];
     }
@@ -244,7 +244,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setArrivalFlightNumber($arrival_flight_number)
+    public function setArrivalFlightNumber($arrival_flight_number): static
     {
         $this->container['arrival_flight_number'] = $arrival_flight_number;
 
@@ -256,7 +256,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getArrivalShipName()
+    public function getArrivalShipName(): string
     {
         return $this->container['arrival_ship_name'];
     }
@@ -268,7 +268,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setArrivalShipName($arrival_ship_name)
+    public function setArrivalShipName($arrival_ship_name): static
     {
         $this->container['arrival_ship_name'] = $arrival_ship_name;
 
@@ -280,7 +280,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TrainInfo
      */
-    public function getArrivalTrainInfo()
+    public function getArrivalTrainInfo(): TrainInfo
     {
         return $this->container['arrival_train_info'];
     }
@@ -292,7 +292,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setArrivalTrainInfo($arrival_train_info)
+    public function setArrivalTrainInfo($arrival_train_info): static
     {
         $this->container['arrival_train_info'] = $arrival_train_info;
 
@@ -304,7 +304,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getDepartureFlightNumber()
+    public function getDepartureFlightNumber(): string
     {
         return $this->container['departure_flight_number'];
     }
@@ -316,7 +316,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDepartureFlightNumber($departure_flight_number)
+    public function setDepartureFlightNumber($departure_flight_number): static
     {
         $this->container['departure_flight_number'] = $departure_flight_number;
 
@@ -328,7 +328,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getDepartureShipName()
+    public function getDepartureShipName(): string
     {
         return $this->container['departure_ship_name'];
     }
@@ -340,7 +340,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDepartureShipName($departure_ship_name)
+    public function setDepartureShipName($departure_ship_name): static
     {
         $this->container['departure_ship_name'] = $departure_ship_name;
 
@@ -352,7 +352,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TrainInfo
      */
-    public function getDepartureTrainInfo()
+    public function getDepartureTrainInfo(): TrainInfo
     {
         return $this->container['departure_train_info'];
     }
@@ -364,7 +364,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDepartureTrainInfo($departure_train_info)
+    public function setDepartureTrainInfo($departure_train_info): static
     {
         $this->container['departure_train_info'] = $departure_train_info;
 
@@ -377,7 +377,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -389,7 +389,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -402,7 +402,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -418,7 +418,7 @@ class Detail implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/DropoffInformation.php
+++ b/lib/Model/DropoffInformation.php
@@ -80,7 +80,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -90,7 +90,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -138,7 +138,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -148,7 +148,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -158,7 +158,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -168,7 +168,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -202,7 +202,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -215,7 +215,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -226,7 +226,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getAddress()
+    public function getAddress(): string
     {
         return $this->container['address'];
     }
@@ -238,7 +238,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setAddress($address)
+    public function setAddress($address): static
     {
         $this->container['address'] = $address;
 
@@ -250,7 +250,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getCountry()
+    public function getCountry(): string
     {
         return $this->container['country'];
     }
@@ -262,7 +262,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCountry($country)
+    public function setCountry($country): static
     {
         $this->container['country'] = $country;
 
@@ -274,7 +274,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->container['name'];
     }
@@ -286,7 +286,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName($name): static
     {
         $this->container['name'] = $name;
 
@@ -298,7 +298,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getTown()
+    public function getTown(): string
     {
         return $this->container['town'];
     }
@@ -310,7 +310,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTown($town)
+    public function setTown($town): static
     {
         $this->container['town'] = $town;
 
@@ -322,7 +322,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getZip()
+    public function getZip(): string
     {
         return $this->container['zip'];
     }
@@ -334,7 +334,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setZip($zip)
+    public function setZip($zip): static
     {
         $this->container['zip'] = $zip;
 
@@ -347,7 +347,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -359,7 +359,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -372,7 +372,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -388,7 +388,7 @@ class DropoffInformation implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/Error.php
+++ b/lib/Model/Error.php
@@ -88,7 +88,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -98,7 +98,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -158,7 +158,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -168,7 +168,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -178,7 +178,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -188,7 +188,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -226,7 +226,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -239,7 +239,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -250,7 +250,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->container['code'];
     }
@@ -262,7 +262,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCode($code)
+    public function setCode($code): static
     {
         $this->container['code'] = $code;
 
@@ -274,7 +274,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getDateTime()
+    public function getDateTime(): string
     {
         return $this->container['date_time'];
     }
@@ -286,7 +286,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDateTime($date_time)
+    public function setDateTime($date_time): static
     {
         $this->container['date_time'] = $date_time;
 
@@ -298,7 +298,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->container['description'];
     }
@@ -310,7 +310,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDescription($description)
+    public function setDescription($description): static
     {
         $this->container['description'] = $description;
 
@@ -322,7 +322,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\FieldError[]
      */
-    public function getFieldErrors()
+    public function getFieldErrors(): array
     {
         return $this->container['field_errors'];
     }
@@ -334,7 +334,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setFieldErrors($field_errors)
+    public function setFieldErrors($field_errors): static
     {
         $this->container['field_errors'] = $field_errors;
 
@@ -346,7 +346,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return bool
      */
-    public function getIsBadRequest()
+    public function getIsBadRequest(): bool
     {
         return $this->container['is_bad_request'];
     }
@@ -358,7 +358,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setIsBadRequest($is_bad_request)
+    public function setIsBadRequest($is_bad_request): static
     {
         $this->container['is_bad_request'] = $is_bad_request;
 
@@ -370,7 +370,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->container['message'];
     }
@@ -382,7 +382,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setMessage($message)
+    public function setMessage($message): static
     {
         $this->container['message'] = $message;
 
@@ -394,7 +394,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Error
      */
-    public function getNestedError()
+    public function getNestedError(): Error
     {
         return $this->container['nested_error'];
     }
@@ -406,7 +406,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setNestedError($nested_error)
+    public function setNestedError($nested_error): static
     {
         $this->container['nested_error'] = $nested_error;
 
@@ -418,7 +418,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getServiceName()
+    public function getServiceName(): string
     {
         return $this->container['service_name'];
     }
@@ -430,7 +430,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setServiceName($service_name)
+    public function setServiceName($service_name): static
     {
         $this->container['service_name'] = $service_name;
 
@@ -442,7 +442,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getTraceId()
+    public function getTraceId(): string
     {
         return $this->container['trace_id'];
     }
@@ -454,7 +454,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTraceId($trace_id)
+    public function setTraceId($trace_id): static
     {
         $this->container['trace_id'] = $trace_id;
 
@@ -467,7 +467,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -479,7 +479,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -492,7 +492,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -508,7 +508,7 @@ class Error implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/FieldError.php
+++ b/lib/Model/FieldError.php
@@ -76,7 +76,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -86,7 +86,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -128,7 +128,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -138,7 +138,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -148,7 +148,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -158,7 +158,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -190,7 +190,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -203,7 +203,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -214,7 +214,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->container['code'];
     }
@@ -226,7 +226,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCode($code)
+    public function setCode($code): static
     {
         $this->container['code'] = $code;
 
@@ -238,7 +238,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getField()
+    public function getField(): string
     {
         return $this->container['field'];
     }
@@ -250,7 +250,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setField($field)
+    public function setField($field): static
     {
         $this->container['field'] = $field;
 
@@ -262,7 +262,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->container['message'];
     }
@@ -274,7 +274,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setMessage($message)
+    public function setMessage($message): static
     {
         $this->container['message'] = $message;
 
@@ -287,7 +287,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -299,7 +299,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -312,7 +312,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -328,7 +328,7 @@ class FieldError implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/Image.php
+++ b/lib/Model/Image.php
@@ -74,7 +74,7 @@ class Image implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -84,7 +84,7 @@ class Image implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -123,7 +123,7 @@ class Image implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -133,7 +133,7 @@ class Image implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -143,7 +143,7 @@ class Image implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -153,7 +153,7 @@ class Image implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -168,7 +168,7 @@ const TYPE_EXTRALARGE = 'EXTRALARGE';
      *
      * @return string[]
      */
-    public function getTypeAllowableValues()
+    public function getTypeAllowableValues(): array
     {
         return [
             self::TYPE_SMALL,
@@ -201,7 +201,7 @@ self::TYPE_EXTRALARGE,        ];
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -228,7 +228,7 @@ self::TYPE_EXTRALARGE,        ];
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -239,7 +239,7 @@ self::TYPE_EXTRALARGE,        ];
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->container['type'];
     }
@@ -251,7 +251,7 @@ self::TYPE_EXTRALARGE,        ];
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
@@ -272,7 +272,7 @@ self::TYPE_EXTRALARGE,        ];
      *
      * @return string
      */
-    public function getUrl()
+    public function getUrl(): string
     {
         return $this->container['url'];
     }
@@ -284,7 +284,7 @@ self::TYPE_EXTRALARGE,        ];
      *
      * @return $this
      */
-    public function setUrl($url)
+    public function setUrl($url): static
     {
         $this->container['url'] = $url;
 
@@ -297,7 +297,7 @@ self::TYPE_EXTRALARGE,        ];
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -309,7 +309,7 @@ self::TYPE_EXTRALARGE,        ];
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -322,7 +322,7 @@ self::TYPE_EXTRALARGE,        ];
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -338,7 +338,7 @@ self::TYPE_EXTRALARGE,        ];
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/InvoiceCompany.php
+++ b/lib/Model/InvoiceCompany.php
@@ -74,7 +74,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -84,7 +84,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -123,7 +123,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -133,7 +133,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -143,7 +143,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -153,7 +153,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -184,7 +184,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -203,7 +203,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -214,7 +214,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->container['name'];
     }
@@ -226,7 +226,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName($name): static
     {
         $this->container['name'] = $name;
 
@@ -238,7 +238,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getVatNumber()
+    public function getVatNumber(): string
     {
         return $this->container['vat_number'];
     }
@@ -250,7 +250,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setVatNumber($vat_number)
+    public function setVatNumber($vat_number): static
     {
         $this->container['vat_number'] = $vat_number;
 
@@ -263,7 +263,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -275,7 +275,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -288,7 +288,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -304,7 +304,7 @@ class InvoiceCompany implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/Link.php
+++ b/lib/Model/Link.php
@@ -76,7 +76,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -86,7 +86,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -128,7 +128,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -138,7 +138,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -148,7 +148,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -158,7 +158,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -190,7 +190,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -203,7 +203,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -214,7 +214,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getHref()
+    public function getHref(): string
     {
         return $this->container['href'];
     }
@@ -226,7 +226,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setHref($href)
+    public function setHref($href): static
     {
         $this->container['href'] = $href;
 
@@ -238,7 +238,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->container['method'];
     }
@@ -250,7 +250,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setMethod($method)
+    public function setMethod($method): static
     {
         $this->container['method'] = $method;
 
@@ -262,7 +262,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getRel()
+    public function getRel(): string
     {
         return $this->container['rel'];
     }
@@ -274,7 +274,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setRel($rel)
+    public function setRel($rel): static
     {
         $this->container['rel'] = $rel;
 
@@ -287,7 +287,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -299,7 +299,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -312,7 +312,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -328,7 +328,7 @@ class Link implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/ModelInterface.php
+++ b/lib/Model/ModelInterface.php
@@ -41,49 +41,49 @@ interface ModelInterface
      *
      * @return string
      */
-    public function getModelName();
+    public function getModelName(): string;
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
      */
-    public static function swaggerTypes();
+    public static function swaggerTypes(): array;
 
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
      * @return array
      */
-    public static function swaggerFormats();
+    public static function swaggerFormats(): array;
 
     /**
      * Array of attributes where the key is the local name, and the value is the original name
      *
      * @return array
      */
-    public static function attributeMap();
+    public static function attributeMap(): array;
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
      * @return array
      */
-    public static function setters();
+    public static function setters(): array;
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
      * @return array
      */
-    public static function getters();
+    public static function getters(): array;
 
     /**
      * Show all the invalid properties with reasons.
      *
      * @return array
      */
-    public function listInvalidProperties();
+    public function listInvalidProperties(): array;
 
     /**
      * Validate all the properties in the model
@@ -91,5 +91,5 @@ interface ModelInterface
      *
      * @return bool
      */
-    public function valid();
+    public function valid(): bool;
 }

--- a/lib/Model/ModificationsPolicies.php
+++ b/lib/Model/ModificationsPolicies.php
@@ -74,7 +74,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -84,7 +84,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -123,7 +123,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -133,7 +133,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -143,7 +143,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -153,7 +153,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -184,7 +184,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -197,7 +197,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -208,7 +208,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return bool
      */
-    public function getCancellation()
+    public function getCancellation(): bool
     {
         return $this->container['cancellation'];
     }
@@ -220,7 +220,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCancellation($cancellation)
+    public function setCancellation($cancellation): static
     {
         $this->container['cancellation'] = $cancellation;
 
@@ -232,7 +232,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return bool
      */
-    public function getModification()
+    public function getModification(): bool
     {
         return $this->container['modification'];
     }
@@ -244,7 +244,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setModification($modification)
+    public function setModification($modification): static
     {
         $this->container['modification'] = $modification;
 
@@ -257,7 +257,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -269,7 +269,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -282,7 +282,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -298,7 +298,7 @@ class ModificationsPolicies implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/Occupancy.php
+++ b/lib/Model/Occupancy.php
@@ -76,7 +76,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -86,7 +86,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -128,7 +128,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -138,7 +138,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -148,7 +148,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -158,7 +158,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -190,7 +190,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -212,7 +212,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -223,7 +223,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return int
      */
-    public function getAdults()
+    public function getAdults(): int
     {
         return $this->container['adults'];
     }
@@ -235,7 +235,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setAdults($adults)
+    public function setAdults($adults): static
     {
         $this->container['adults'] = $adults;
 
@@ -247,7 +247,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return int
      */
-    public function getChildren()
+    public function getChildren(): int
     {
         return $this->container['children'];
     }
@@ -259,7 +259,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setChildren($children)
+    public function setChildren($children): static
     {
         $this->container['children'] = $children;
 
@@ -271,7 +271,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return int
      */
-    public function getInfants()
+    public function getInfants(): int
     {
         return $this->container['infants'];
     }
@@ -283,7 +283,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setInfants($infants)
+    public function setInfants($infants): static
     {
         $this->container['infants'] = $infants;
 
@@ -296,7 +296,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -308,7 +308,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -321,7 +321,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -337,7 +337,7 @@ class Occupancy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/Pax.php
+++ b/lib/Model/Pax.php
@@ -80,7 +80,7 @@ class Pax implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -90,7 +90,7 @@ class Pax implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -138,7 +138,7 @@ class Pax implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -148,7 +148,7 @@ class Pax implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -158,7 +158,7 @@ class Pax implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -168,7 +168,7 @@ class Pax implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -182,7 +182,7 @@ const TYPE_INFANT = 'INFANT';
      *
      * @return string[]
      */
-    public function getTypeAllowableValues()
+    public function getTypeAllowableValues(): array
     {
         return [
             self::TYPE_ADULT,
@@ -217,7 +217,7 @@ self::TYPE_INFANT,        ];
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -250,7 +250,7 @@ self::TYPE_INFANT,        ];
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -261,7 +261,7 @@ self::TYPE_INFANT,        ];
      *
      * @return string
      */
-    public function getEmail()
+    public function getEmail(): string
     {
         return $this->container['email'];
     }
@@ -273,7 +273,7 @@ self::TYPE_INFANT,        ];
      *
      * @return $this
      */
-    public function setEmail($email)
+    public function setEmail($email): static
     {
         $this->container['email'] = $email;
 
@@ -285,7 +285,7 @@ self::TYPE_INFANT,        ];
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->container['name'];
     }
@@ -297,7 +297,7 @@ self::TYPE_INFANT,        ];
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName($name): static
     {
         $this->container['name'] = $name;
 
@@ -309,7 +309,7 @@ self::TYPE_INFANT,        ];
      *
      * @return string
      */
-    public function getPhone()
+    public function getPhone(): string
     {
         return $this->container['phone'];
     }
@@ -321,7 +321,7 @@ self::TYPE_INFANT,        ];
      *
      * @return $this
      */
-    public function setPhone($phone)
+    public function setPhone($phone): static
     {
         $this->container['phone'] = $phone;
 
@@ -333,7 +333,7 @@ self::TYPE_INFANT,        ];
      *
      * @return string
      */
-    public function getSurname()
+    public function getSurname(): string
     {
         return $this->container['surname'];
     }
@@ -345,7 +345,7 @@ self::TYPE_INFANT,        ];
      *
      * @return $this
      */
-    public function setSurname($surname)
+    public function setSurname($surname): static
     {
         $this->container['surname'] = $surname;
 
@@ -357,7 +357,7 @@ self::TYPE_INFANT,        ];
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->container['type'];
     }
@@ -369,7 +369,7 @@ self::TYPE_INFANT,        ];
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!is_null($type) && !in_array($type, $allowedValues, true)) {
@@ -391,7 +391,7 @@ self::TYPE_INFANT,        ];
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -403,7 +403,7 @@ self::TYPE_INFANT,        ];
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -416,7 +416,7 @@ self::TYPE_INFANT,        ];
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -432,7 +432,7 @@ self::TYPE_INFANT,        ];
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/Pickup.php
+++ b/lib/Model/Pickup.php
@@ -94,7 +94,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -104,7 +104,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -173,7 +173,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -183,7 +183,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -193,7 +193,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -203,7 +203,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -244,7 +244,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -257,7 +257,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -268,7 +268,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getAddress()
+    public function getAddress(): string
     {
         return $this->container['address'];
     }
@@ -280,7 +280,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setAddress($address)
+    public function setAddress($address): static
     {
         $this->container['address'] = $address;
 
@@ -292,7 +292,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return double
      */
-    public function getAltitude()
+    public function getAltitude(): float
     {
         return $this->container['altitude'];
     }
@@ -304,7 +304,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setAltitude($altitude)
+    public function setAltitude($altitude): static
     {
         $this->container['altitude'] = $altitude;
 
@@ -316,7 +316,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\CheckPickup
      */
-    public function getCheckPickup()
+    public function getCheckPickup(): CheckPickup
     {
         return $this->container['check_pickup'];
     }
@@ -328,7 +328,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCheckPickup($check_pickup)
+    public function setCheckPickup($check_pickup): static
     {
         $this->container['check_pickup'] = $check_pickup;
 
@@ -340,7 +340,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->container['description'];
     }
@@ -352,7 +352,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDescription($description)
+    public function setDescription($description): static
     {
         $this->container['description'] = $description;
 
@@ -364,7 +364,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getImage()
+    public function getImage(): string
     {
         return $this->container['image'];
     }
@@ -376,7 +376,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setImage($image)
+    public function setImage($image): static
     {
         $this->container['image'] = $image;
 
@@ -388,7 +388,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return double
      */
-    public function getLatitude()
+    public function getLatitude(): float
     {
         return $this->container['latitude'];
     }
@@ -400,7 +400,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setLatitude($latitude)
+    public function setLatitude($latitude): static
     {
         $this->container['latitude'] = $latitude;
 
@@ -412,7 +412,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return double
      */
-    public function getLongitude()
+    public function getLongitude(): float
     {
         return $this->container['longitude'];
     }
@@ -424,7 +424,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setLongitude($longitude)
+    public function setLongitude($longitude): static
     {
         $this->container['longitude'] = $longitude;
 
@@ -436,7 +436,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getNumber()
+    public function getNumber(): string
     {
         return $this->container['number'];
     }
@@ -448,7 +448,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setNumber($number)
+    public function setNumber($number): static
     {
         $this->container['number'] = $number;
 
@@ -460,7 +460,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return int
      */
-    public function getPickupId()
+    public function getPickupId(): int
     {
         return $this->container['pickup_id'];
     }
@@ -472,7 +472,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setPickupId($pickup_id)
+    public function setPickupId($pickup_id): static
     {
         $this->container['pickup_id'] = $pickup_id;
 
@@ -484,7 +484,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getStopName()
+    public function getStopName(): string
     {
         return $this->container['stop_name'];
     }
@@ -496,7 +496,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setStopName($stop_name)
+    public function setStopName($stop_name): static
     {
         $this->container['stop_name'] = $stop_name;
 
@@ -508,7 +508,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getTown()
+    public function getTown(): string
     {
         return $this->container['town'];
     }
@@ -520,7 +520,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTown($town)
+    public function setTown($town): static
     {
         $this->container['town'] = $town;
 
@@ -532,7 +532,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getZip()
+    public function getZip(): string
     {
         return $this->container['zip'];
     }
@@ -544,7 +544,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setZip($zip)
+    public function setZip($zip): static
     {
         $this->container['zip'] = $zip;
 
@@ -557,7 +557,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -569,7 +569,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -582,7 +582,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -598,7 +598,7 @@ class Pickup implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/PickupInformation.php
+++ b/lib/Model/PickupInformation.php
@@ -80,7 +80,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -90,7 +90,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -138,7 +138,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -148,7 +148,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -158,7 +158,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -168,7 +168,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -202,7 +202,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -227,7 +227,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -238,7 +238,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getDate()
+    public function getDate(): string
     {
         return $this->container['date'];
     }
@@ -250,7 +250,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDate($date)
+    public function setDate($date): static
     {
         $this->container['date'] = $date;
 
@@ -262,7 +262,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferPoint
      */
-    public function getFrom()
+    public function getFrom(): TransferPoint
     {
         return $this->container['from'];
     }
@@ -274,7 +274,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setFrom($from)
+    public function setFrom($from): static
     {
         $this->container['from'] = $from;
 
@@ -286,7 +286,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Pickup
      */
-    public function getPickup()
+    public function getPickup(): Pickup
     {
         return $this->container['pickup'];
     }
@@ -298,7 +298,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setPickup($pickup)
+    public function setPickup($pickup): static
     {
         $this->container['pickup'] = $pickup;
 
@@ -310,7 +310,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getTime()
+    public function getTime(): string
     {
         return $this->container['time'];
     }
@@ -322,7 +322,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTime($time)
+    public function setTime($time): static
     {
         $this->container['time'] = $time;
 
@@ -334,7 +334,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferPoint
      */
-    public function getTo()
+    public function getTo(): TransferPoint
     {
         return $this->container['to'];
     }
@@ -346,7 +346,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTo($to)
+    public function setTo($to): static
     {
         $this->container['to'] = $to;
 
@@ -359,7 +359,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -371,7 +371,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -384,7 +384,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -400,7 +400,7 @@ class PickupInformation implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/Price.php
+++ b/lib/Model/Price.php
@@ -76,7 +76,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -86,7 +86,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -128,7 +128,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -138,7 +138,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -148,7 +148,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -158,7 +158,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -190,7 +190,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -212,7 +212,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -223,7 +223,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getCurrencyId()
+    public function getCurrencyId(): string
     {
         return $this->container['currency_id'];
     }
@@ -235,7 +235,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCurrencyId($currency_id)
+    public function setCurrencyId($currency_id): static
     {
         $this->container['currency_id'] = $currency_id;
 
@@ -247,7 +247,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return float
      */
-    public function getNetAmount()
+    public function getNetAmount(): float
     {
         return $this->container['net_amount'];
     }
@@ -259,7 +259,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setNetAmount($net_amount)
+    public function setNetAmount($net_amount): static
     {
         $this->container['net_amount'] = $net_amount;
 
@@ -271,7 +271,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return float
      */
-    public function getTotalAmount()
+    public function getTotalAmount(): float
     {
         return $this->container['total_amount'];
     }
@@ -283,7 +283,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTotalAmount($total_amount)
+    public function setTotalAmount($total_amount): static
     {
         $this->container['total_amount'] = $total_amount;
 
@@ -296,7 +296,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -308,7 +308,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -321,7 +321,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -337,7 +337,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/Route.php
+++ b/lib/Model/Route.php
@@ -82,7 +82,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -92,7 +92,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -143,7 +143,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -153,7 +153,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -163,7 +163,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -173,7 +173,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -208,7 +208,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -233,7 +233,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -244,7 +244,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getDate()
+    public function getDate(): string
     {
         return $this->container['date'];
     }
@@ -256,7 +256,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDate($date)
+    public function setDate($date): static
     {
         $this->container['date'] = $date;
 
@@ -268,7 +268,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Error
      */
-    public function getError()
+    public function getError(): Error
     {
         return $this->container['error'];
     }
@@ -280,7 +280,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setError($error)
+    public function setError($error): static
     {
         $this->container['error'] = $error;
 
@@ -292,7 +292,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->container['id'];
     }
@@ -304,7 +304,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -316,7 +316,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferServiceAvail[]
      */
-    public function getServices()
+    public function getServices(): array
     {
         return $this->container['services'];
     }
@@ -328,7 +328,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setServices($services)
+    public function setServices($services): static
     {
         $this->container['services'] = $services;
 
@@ -340,7 +340,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getTime()
+    public function getTime(): string
     {
         return $this->container['time'];
     }
@@ -352,7 +352,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTime($time)
+    public function setTime($time): static
     {
         $this->container['time'] = $time;
 
@@ -364,7 +364,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return int
      */
-    public function getUnfilteredTotalCount()
+    public function getUnfilteredTotalCount(): int
     {
         return $this->container['unfiltered_total_count'];
     }
@@ -376,7 +376,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setUnfilteredTotalCount($unfiltered_total_count)
+    public function setUnfilteredTotalCount($unfiltered_total_count): static
     {
         $this->container['unfiltered_total_count'] = $unfiltered_total_count;
 
@@ -389,7 +389,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -401,7 +401,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -414,7 +414,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -430,7 +430,7 @@ class Route implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/RouteRequest.php
+++ b/lib/Model/RouteRequest.php
@@ -73,7 +73,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -83,7 +83,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -122,7 +122,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -132,7 +132,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -142,7 +142,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -152,7 +152,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -183,7 +183,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -196,7 +196,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -207,7 +207,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getDateTime()
+    public function getDateTime(): string
     {
         return $this->container['date_time'];
     }
@@ -219,7 +219,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDateTime($date_time)
+    public function setDateTime($date_time): static
     {
         $this->container['date_time'] = $date_time;
 
@@ -231,7 +231,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->container['id'];
     }
@@ -243,7 +243,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -256,7 +256,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -268,7 +268,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -281,7 +281,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -297,7 +297,7 @@ class RouteRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/RouteRequestDTO.php
+++ b/lib/Model/RouteRequestDTO.php
@@ -74,7 +74,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -84,7 +84,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -123,7 +123,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -133,7 +133,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -143,7 +143,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -153,7 +153,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -184,7 +184,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -203,7 +203,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -214,7 +214,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getDateTime()
+    public function getDateTime(): string
     {
         return $this->container['date_time'];
     }
@@ -226,7 +226,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDateTime($date_time)
+    public function setDateTime($date_time): static
     {
         $this->container['date_time'] = $date_time;
 
@@ -238,7 +238,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->container['id'];
     }
@@ -250,7 +250,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -263,7 +263,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -275,7 +275,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -288,7 +288,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -304,7 +304,7 @@ class RouteRequestDTO implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TrainInfo.php
+++ b/lib/Model/TrainInfo.php
@@ -74,7 +74,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -84,7 +84,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -123,7 +123,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -133,7 +133,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -143,7 +143,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -153,7 +153,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -184,7 +184,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -203,7 +203,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -214,7 +214,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getTrainCompanyName()
+    public function getTrainCompanyName(): string
     {
         return $this->container['train_company_name'];
     }
@@ -226,7 +226,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTrainCompanyName($train_company_name)
+    public function setTrainCompanyName($train_company_name): static
     {
         $this->container['train_company_name'] = $train_company_name;
 
@@ -238,7 +238,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getTrainNumber()
+    public function getTrainNumber(): string
     {
         return $this->container['train_number'];
     }
@@ -250,7 +250,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTrainNumber($train_number)
+    public function setTrainNumber($train_number): static
     {
         $this->container['train_number'] = $train_number;
 
@@ -263,7 +263,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -275,7 +275,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -288,7 +288,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -304,7 +304,7 @@ class TrainInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TransferConfirm.php
+++ b/lib/Model/TransferConfirm.php
@@ -80,7 +80,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -90,7 +90,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -138,7 +138,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -148,7 +148,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -158,7 +158,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -168,7 +168,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -202,7 +202,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -218,7 +218,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -229,7 +229,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Detail
      */
-    public function getDetail()
+    public function getDetail(): Detail
     {
         return $this->container['detail'];
     }
@@ -241,7 +241,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDetail($detail)
+    public function setDetail($detail): static
     {
         $this->container['detail'] = $detail;
 
@@ -253,7 +253,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\DropoffInformation
      */
-    public function getDropoffInformation()
+    public function getDropoffInformation(): DropoffInformation
     {
         return $this->container['dropoff_information'];
     }
@@ -265,7 +265,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDropoffInformation($dropoff_information)
+    public function setDropoffInformation($dropoff_information): static
     {
         $this->container['dropoff_information'] = $dropoff_information;
 
@@ -277,7 +277,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\ConfirmPickupInformation
      */
-    public function getPickupInformation()
+    public function getPickupInformation(): ConfirmPickupInformation
     {
         return $this->container['pickup_information'];
     }
@@ -289,7 +289,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setPickupInformation($pickup_information)
+    public function setPickupInformation($pickup_information): static
     {
         $this->container['pickup_information'] = $pickup_information;
 
@@ -301,7 +301,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getRateKey()
+    public function getRateKey(): string
     {
         return $this->container['rate_key'];
     }
@@ -313,7 +313,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setRateKey($rate_key)
+    public function setRateKey($rate_key): static
     {
         $this->container['rate_key'] = $rate_key;
 
@@ -325,7 +325,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferDetail[]
      */
-    public function getTransferDetails()
+    public function getTransferDetails(): array
     {
         return $this->container['transfer_details'];
     }
@@ -337,7 +337,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTransferDetails($transfer_details)
+    public function setTransferDetails($transfer_details): static
     {
         $this->container['transfer_details'] = $transfer_details;
 
@@ -350,7 +350,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -362,7 +362,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -375,7 +375,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -391,7 +391,7 @@ class TransferConfirm implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TransferDateTime.php
+++ b/lib/Model/TransferDateTime.php
@@ -74,7 +74,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -84,7 +84,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -123,7 +123,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -133,7 +133,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -143,7 +143,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -153,7 +153,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -184,7 +184,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -203,7 +203,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -214,7 +214,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getDate()
+    public function getDate(): string
     {
         return $this->container['date'];
     }
@@ -226,7 +226,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setDate($date)
+    public function setDate($date): static
     {
         $this->container['date'] = $date;
 
@@ -238,7 +238,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getTime()
+    public function getTime(): string
     {
         return $this->container['time'];
     }
@@ -250,7 +250,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTime($time)
+    public function setTime($time): static
     {
         $this->container['time'] = $time;
 
@@ -263,7 +263,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -275,7 +275,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -288,7 +288,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -304,7 +304,7 @@ class TransferDateTime implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TransferDetail.php
+++ b/lib/Model/TransferDetail.php
@@ -78,7 +78,7 @@ class TransferDetail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -88,7 +88,7 @@ class TransferDetail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -133,7 +133,7 @@ class TransferDetail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -143,7 +143,7 @@ class TransferDetail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -153,7 +153,7 @@ class TransferDetail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -163,7 +163,7 @@ class TransferDetail implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -179,7 +179,7 @@ const TYPE_TRAIN = 'TRAIN';
      *
      * @return string[]
      */
-    public function getDirectionAllowableValues()
+    public function getDirectionAllowableValues(): array
     {
         return [
             self::DIRECTION_ARRIVAL,
@@ -190,7 +190,7 @@ self::DIRECTION_DEPARTURE,        ];
      *
      * @return string[]
      */
-    public function getTypeAllowableValues()
+    public function getTypeAllowableValues(): array
     {
         return [
             self::TYPE_FLIGHT,
@@ -224,7 +224,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -253,7 +253,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -264,7 +264,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return string
      */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->container['code'];
     }
@@ -276,7 +276,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return $this
      */
-    public function setCode($code)
+    public function setCode($code): static
     {
         $this->container['code'] = $code;
 
@@ -288,7 +288,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return string
      */
-    public function getCompanyName()
+    public function getCompanyName(): string
     {
         return $this->container['company_name'];
     }
@@ -300,7 +300,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return $this
      */
-    public function setCompanyName($company_name)
+    public function setCompanyName($company_name): static
     {
         $this->container['company_name'] = $company_name;
 
@@ -312,7 +312,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return string
      */
-    public function getDirection()
+    public function getDirection(): string
     {
         return $this->container['direction'];
     }
@@ -324,7 +324,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return $this
      */
-    public function setDirection($direction)
+    public function setDirection($direction): static
     {
         $allowedValues = $this->getDirectionAllowableValues();
         if (!is_null($direction) && !in_array($direction, $allowedValues, true)) {
@@ -345,7 +345,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->container['type'];
     }
@@ -357,7 +357,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!is_null($type) && !in_array($type, $allowedValues, true)) {
@@ -379,7 +379,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -391,7 +391,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -404,7 +404,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -420,7 +420,7 @@ self::TYPE_TRAIN,        ];
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TransferDetailInfo.php
+++ b/lib/Model/TransferDetailInfo.php
@@ -78,7 +78,7 @@ class TransferDetailInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -88,7 +88,7 @@ class TransferDetailInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -133,7 +133,7 @@ class TransferDetailInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -143,7 +143,7 @@ class TransferDetailInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -153,7 +153,7 @@ class TransferDetailInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -163,7 +163,7 @@ class TransferDetailInfo implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -176,7 +176,7 @@ const TYPE_GENERIC_GUIDELINES = 'GENERIC_GUIDELINES';
      *
      * @return string[]
      */
-    public function getTypeAllowableValues()
+    public function getTypeAllowableValues(): array
     {
         return [
             self::TYPE_GENERAL_INFO,
@@ -209,7 +209,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -242,7 +242,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -253,7 +253,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->container['description'];
     }
@@ -265,7 +265,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return $this
      */
-    public function setDescription($description)
+    public function setDescription($description): static
     {
         $this->container['description'] = $description;
 
@@ -277,7 +277,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->container['id'];
     }
@@ -289,7 +289,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -301,7 +301,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->container['name'];
     }
@@ -313,7 +313,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName($name): static
     {
         $this->container['name'] = $name;
 
@@ -325,7 +325,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->container['type'];
     }
@@ -337,7 +337,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
@@ -359,7 +359,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -371,7 +371,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -384,7 +384,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -400,7 +400,7 @@ self::TYPE_GENERIC_GUIDELINES,        ];
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TransferPoint.php
+++ b/lib/Model/TransferPoint.php
@@ -76,7 +76,7 @@ class TransferPoint implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -86,7 +86,7 @@ class TransferPoint implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -128,7 +128,7 @@ class TransferPoint implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -138,7 +138,7 @@ class TransferPoint implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -148,7 +148,7 @@ class TransferPoint implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -158,7 +158,7 @@ class TransferPoint implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -175,7 +175,7 @@ const TYPE_GPS = 'GPS';
      *
      * @return string[]
      */
-    public function getTypeAllowableValues()
+    public function getTypeAllowableValues(): array
     {
         return [
             self::TYPE_GIATA,
@@ -211,7 +211,7 @@ self::TYPE_GPS,        ];
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -238,7 +238,7 @@ self::TYPE_GPS,        ];
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -249,7 +249,7 @@ self::TYPE_GPS,        ];
      *
      * @return string
      */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->container['code'];
     }
@@ -261,7 +261,7 @@ self::TYPE_GPS,        ];
      *
      * @return $this
      */
-    public function setCode($code)
+    public function setCode($code): static
     {
         $this->container['code'] = $code;
 
@@ -273,7 +273,7 @@ self::TYPE_GPS,        ];
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->container['description'];
     }
@@ -285,7 +285,7 @@ self::TYPE_GPS,        ];
      *
      * @return $this
      */
-    public function setDescription($description)
+    public function setDescription($description): static
     {
         $this->container['description'] = $description;
 
@@ -297,7 +297,7 @@ self::TYPE_GPS,        ];
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->container['type'];
     }
@@ -309,7 +309,7 @@ self::TYPE_GPS,        ];
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
@@ -331,7 +331,7 @@ self::TYPE_GPS,        ];
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -343,7 +343,7 @@ self::TYPE_GPS,        ];
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -356,7 +356,7 @@ self::TYPE_GPS,        ];
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -372,7 +372,7 @@ self::TYPE_GPS,        ];
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TransferRemarks.php
+++ b/lib/Model/TransferRemarks.php
@@ -76,7 +76,7 @@ class TransferRemarks implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -86,7 +86,7 @@ class TransferRemarks implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -128,7 +128,7 @@ class TransferRemarks implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -138,7 +138,7 @@ class TransferRemarks implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -148,7 +148,7 @@ class TransferRemarks implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -158,7 +158,7 @@ class TransferRemarks implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -171,7 +171,7 @@ const TYPE_AGENCY = 'AGENCY';
      *
      * @return string[]
      */
-    public function getTypeAllowableValues()
+    public function getTypeAllowableValues(): array
     {
         return [
             self::TYPE_CONTRACT,
@@ -203,7 +203,7 @@ self::TYPE_AGENCY,        ];
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -224,7 +224,7 @@ self::TYPE_AGENCY,        ];
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -235,7 +235,7 @@ self::TYPE_AGENCY,        ];
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->container['description'];
     }
@@ -247,7 +247,7 @@ self::TYPE_AGENCY,        ];
      *
      * @return $this
      */
-    public function setDescription($description)
+    public function setDescription($description): static
     {
         $this->container['description'] = $description;
 
@@ -259,7 +259,7 @@ self::TYPE_AGENCY,        ];
      *
      * @return bool
      */
-    public function getMandatory()
+    public function getMandatory(): bool
     {
         return $this->container['mandatory'];
     }
@@ -271,7 +271,7 @@ self::TYPE_AGENCY,        ];
      *
      * @return $this
      */
-    public function setMandatory($mandatory)
+    public function setMandatory($mandatory): static
     {
         $this->container['mandatory'] = $mandatory;
 
@@ -283,7 +283,7 @@ self::TYPE_AGENCY,        ];
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->container['type'];
     }
@@ -295,7 +295,7 @@ self::TYPE_AGENCY,        ];
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!is_null($type) && !in_array($type, $allowedValues, true)) {
@@ -317,7 +317,7 @@ self::TYPE_AGENCY,        ];
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -329,7 +329,7 @@ self::TYPE_AGENCY,        ];
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -342,7 +342,7 @@ self::TYPE_AGENCY,        ];
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -358,7 +358,7 @@ self::TYPE_AGENCY,        ];
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TransferServiceAvail.php
+++ b/lib/Model/TransferServiceAvail.php
@@ -98,7 +98,7 @@ class TransferServiceAvail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -108,7 +108,7 @@ class TransferServiceAvail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -183,7 +183,7 @@ class TransferServiceAvail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -193,7 +193,7 @@ class TransferServiceAvail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -203,7 +203,7 @@ class TransferServiceAvail implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -213,7 +213,7 @@ class TransferServiceAvail implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -228,7 +228,7 @@ const TRANSFER_TYPE_SHARED = 'SHARED';
      *
      * @return string[]
      */
-    public function getDirectionAllowableValues()
+    public function getDirectionAllowableValues(): array
     {
         return [
             self::DIRECTION_DEPARTURE,
@@ -239,7 +239,7 @@ self::DIRECTION__RETURN,        ];
      *
      * @return string[]
      */
-    public function getTransferTypeAllowableValues()
+    public function getTransferTypeAllowableValues(): array
     {
         return [
             self::TRANSFER_TYPE__PRIVATE,
@@ -282,7 +282,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -344,7 +344,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -355,7 +355,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\CancellationPolicy[]
      */
-    public function getCancellationPolicies()
+    public function getCancellationPolicies(): array
     {
         return $this->container['cancellation_policies'];
     }
@@ -367,7 +367,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setCancellationPolicies($cancellation_policies)
+    public function setCancellationPolicies($cancellation_policies): static
     {
         $this->container['cancellation_policies'] = $cancellation_policies;
 
@@ -379,7 +379,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Category
      */
-    public function getCategory()
+    public function getCategory(): Category
     {
         return $this->container['category'];
     }
@@ -391,7 +391,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setCategory($category)
+    public function setCategory($category): static
     {
         $this->container['category'] = $category;
 
@@ -403,7 +403,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\TransferServiceContent
      */
-    public function getContent()
+    public function getContent(): TransferServiceContent
     {
         return $this->container['content'];
     }
@@ -415,7 +415,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setContent($content)
+    public function setContent($content): static
     {
         $this->container['content'] = $content;
 
@@ -427,7 +427,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getDirection()
+    public function getDirection(): string
     {
         return $this->container['direction'];
     }
@@ -439,7 +439,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setDirection($direction)
+    public function setDirection($direction): static
     {
         $allowedValues = $this->getDirectionAllowableValues();
         if (!in_array($direction, $allowedValues, true)) {
@@ -460,7 +460,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return int
      */
-    public function getFactsheetId()
+    public function getFactsheetId(): int
     {
         return $this->container['factsheet_id'];
     }
@@ -472,7 +472,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setFactsheetId($factsheet_id)
+    public function setFactsheetId($factsheet_id): static
     {
         $this->container['factsheet_id'] = $factsheet_id;
 
@@ -484,7 +484,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return int
      */
-    public function getId()
+    public function getId(): int
     {
         return $this->container['id'];
     }
@@ -496,7 +496,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -508,7 +508,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Link[]
      */
-    public function getLinks()
+    public function getLinks(): array
     {
         return $this->container['links'];
     }
@@ -520,7 +520,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setLinks($links)
+    public function setLinks($links): static
     {
         $this->container['links'] = $links;
 
@@ -532,7 +532,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return int
      */
-    public function getMaxPaxCapacity()
+    public function getMaxPaxCapacity(): int
     {
         return $this->container['max_pax_capacity'];
     }
@@ -544,7 +544,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setMaxPaxCapacity($max_pax_capacity)
+    public function setMaxPaxCapacity($max_pax_capacity): static
     {
         $this->container['max_pax_capacity'] = $max_pax_capacity;
 
@@ -556,7 +556,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return int
      */
-    public function getMinPaxCapacity()
+    public function getMinPaxCapacity(): int
     {
         return $this->container['min_pax_capacity'];
     }
@@ -568,7 +568,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setMinPaxCapacity($min_pax_capacity)
+    public function setMinPaxCapacity($min_pax_capacity): static
     {
         $this->container['min_pax_capacity'] = $min_pax_capacity;
 
@@ -580,7 +580,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\PickupInformation
      */
-    public function getPickupInformation()
+    public function getPickupInformation(): PickupInformation
     {
         return $this->container['pickup_information'];
     }
@@ -592,7 +592,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setPickupInformation($pickup_information)
+    public function setPickupInformation($pickup_information): static
     {
         $this->container['pickup_information'] = $pickup_information;
 
@@ -604,7 +604,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Price
      */
-    public function getPrice()
+    public function getPrice(): Price
     {
         return $this->container['price'];
     }
@@ -616,7 +616,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setPrice($price)
+    public function setPrice($price): static
     {
         $this->container['price'] = $price;
 
@@ -628,7 +628,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getRateKey()
+    public function getRateKey(): string
     {
         return $this->container['rate_key'];
     }
@@ -640,7 +640,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setRateKey($rate_key)
+    public function setRateKey($rate_key): static
     {
         $this->container['rate_key'] = $rate_key;
 
@@ -652,7 +652,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getTransferType()
+    public function getTransferType(): string
     {
         return $this->container['transfer_type'];
     }
@@ -664,7 +664,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setTransferType($transfer_type)
+    public function setTransferType($transfer_type): static
     {
         $allowedValues = $this->getTransferTypeAllowableValues();
         if (!in_array($transfer_type, $allowedValues, true)) {
@@ -685,7 +685,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Vehicle
      */
-    public function getVehicle()
+    public function getVehicle(): Vehicle
     {
         return $this->container['vehicle'];
     }
@@ -697,7 +697,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setVehicle($vehicle)
+    public function setVehicle($vehicle): static
     {
         $this->container['vehicle'] = $vehicle;
 
@@ -710,7 +710,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -722,7 +722,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -735,7 +735,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -751,7 +751,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TransferServiceBooking.php
+++ b/lib/Model/TransferServiceBooking.php
@@ -112,7 +112,7 @@ class TransferServiceBooking implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -122,7 +122,7 @@ class TransferServiceBooking implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -218,7 +218,7 @@ class TransferServiceBooking implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -228,7 +228,7 @@ class TransferServiceBooking implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -238,7 +238,7 @@ class TransferServiceBooking implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -248,7 +248,7 @@ class TransferServiceBooking implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -264,7 +264,7 @@ const TRANSFER_TYPE_SHARED = 'SHARED';
      *
      * @return string[]
      */
-    public function getStatusAllowableValues()
+    public function getStatusAllowableValues(): array
     {
         return [
             self::STATUS_CONFIRMED,
@@ -276,7 +276,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return string[]
      */
-    public function getTransferTypeAllowableValues()
+    public function getTransferTypeAllowableValues(): array
     {
         return [
             self::TRANSFER_TYPE__PRIVATE,
@@ -326,7 +326,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -382,7 +382,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -393,7 +393,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getArrivalFlightNumber()
+    public function getArrivalFlightNumber(): string
     {
         return $this->container['arrival_flight_number'];
     }
@@ -405,7 +405,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setArrivalFlightNumber($arrival_flight_number)
+    public function setArrivalFlightNumber($arrival_flight_number): static
     {
         $this->container['arrival_flight_number'] = $arrival_flight_number;
 
@@ -417,7 +417,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getArrivalShipName()
+    public function getArrivalShipName(): string
     {
         return $this->container['arrival_ship_name'];
     }
@@ -429,7 +429,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setArrivalShipName($arrival_ship_name)
+    public function setArrivalShipName($arrival_ship_name): static
     {
         $this->container['arrival_ship_name'] = $arrival_ship_name;
 
@@ -441,7 +441,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\TrainInfo
      */
-    public function getArrivalTrainInfo()
+    public function getArrivalTrainInfo(): TrainInfo
     {
         return $this->container['arrival_train_info'];
     }
@@ -453,7 +453,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setArrivalTrainInfo($arrival_train_info)
+    public function setArrivalTrainInfo($arrival_train_info): static
     {
         $this->container['arrival_train_info'] = $arrival_train_info;
 
@@ -465,7 +465,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\CancellationPolicy[]
      */
-    public function getCancellationPolicies()
+    public function getCancellationPolicies(): array
     {
         return $this->container['cancellation_policies'];
     }
@@ -477,7 +477,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setCancellationPolicies($cancellation_policies)
+    public function setCancellationPolicies($cancellation_policies): static
     {
         $this->container['cancellation_policies'] = $cancellation_policies;
 
@@ -489,7 +489,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Category
      */
-    public function getCategory()
+    public function getCategory(): Category
     {
         return $this->container['category'];
     }
@@ -501,7 +501,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setCategory($category)
+    public function setCategory($category): static
     {
         $this->container['category'] = $category;
 
@@ -513,7 +513,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\TransferServiceContent
      */
-    public function getContent()
+    public function getContent(): TransferServiceContent
     {
         return $this->container['content'];
     }
@@ -525,7 +525,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setContent($content)
+    public function setContent($content): static
     {
         $this->container['content'] = $content;
 
@@ -537,7 +537,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getDepartureFlightNumber()
+    public function getDepartureFlightNumber(): string
     {
         return $this->container['departure_flight_number'];
     }
@@ -549,7 +549,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setDepartureFlightNumber($departure_flight_number)
+    public function setDepartureFlightNumber($departure_flight_number): static
     {
         $this->container['departure_flight_number'] = $departure_flight_number;
 
@@ -561,7 +561,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getDepartureShipName()
+    public function getDepartureShipName(): string
     {
         return $this->container['departure_ship_name'];
     }
@@ -573,7 +573,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setDepartureShipName($departure_ship_name)
+    public function setDepartureShipName($departure_ship_name): static
     {
         $this->container['departure_ship_name'] = $departure_ship_name;
 
@@ -585,7 +585,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\TrainInfo
      */
-    public function getDepartureTrainInfo()
+    public function getDepartureTrainInfo(): TrainInfo
     {
         return $this->container['departure_train_info'];
     }
@@ -597,7 +597,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setDepartureTrainInfo($departure_train_info)
+    public function setDepartureTrainInfo($departure_train_info): static
     {
         $this->container['departure_train_info'] = $departure_train_info;
 
@@ -609,7 +609,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return int
      */
-    public function getFactsheetId()
+    public function getFactsheetId(): int
     {
         return $this->container['factsheet_id'];
     }
@@ -621,7 +621,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setFactsheetId($factsheet_id)
+    public function setFactsheetId($factsheet_id): static
     {
         $this->container['factsheet_id'] = $factsheet_id;
 
@@ -633,7 +633,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return int
      */
-    public function getId()
+    public function getId(): int
     {
         return $this->container['id'];
     }
@@ -645,7 +645,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -657,7 +657,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Link[]
      */
-    public function getLinks()
+    public function getLinks(): array
     {
         return $this->container['links'];
     }
@@ -669,7 +669,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setLinks($links)
+    public function setLinks($links): static
     {
         $this->container['links'] = $links;
 
@@ -681,7 +681,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Pax[]
      */
-    public function getPaxes()
+    public function getPaxes(): array
     {
         return $this->container['paxes'];
     }
@@ -693,7 +693,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setPaxes($paxes)
+    public function setPaxes($paxes): static
     {
         $this->container['paxes'] = $paxes;
 
@@ -705,7 +705,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\PickupInformation
      */
-    public function getPickupInformation()
+    public function getPickupInformation(): PickupInformation
     {
         return $this->container['pickup_information'];
     }
@@ -717,7 +717,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setPickupInformation($pickup_information)
+    public function setPickupInformation($pickup_information): static
     {
         $this->container['pickup_information'] = $pickup_information;
 
@@ -729,7 +729,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Price
      */
-    public function getPrice()
+    public function getPrice(): Price
     {
         return $this->container['price'];
     }
@@ -741,7 +741,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setPrice($price)
+    public function setPrice($price): static
     {
         $this->container['price'] = $price;
 
@@ -753,7 +753,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getRateKey()
+    public function getRateKey(): string
     {
         return $this->container['rate_key'];
     }
@@ -765,7 +765,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setRateKey($rate_key)
+    public function setRateKey($rate_key): static
     {
         $this->container['rate_key'] = $rate_key;
 
@@ -777,7 +777,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getSourceMarketEmergencyNumber()
+    public function getSourceMarketEmergencyNumber(): string
     {
         return $this->container['source_market_emergency_number'];
     }
@@ -789,7 +789,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setSourceMarketEmergencyNumber($source_market_emergency_number)
+    public function setSourceMarketEmergencyNumber($source_market_emergency_number): static
     {
         $this->container['source_market_emergency_number'] = $source_market_emergency_number;
 
@@ -801,7 +801,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getStatus()
+    public function getStatus(): string
     {
         return $this->container['status'];
     }
@@ -813,7 +813,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setStatus($status)
+    public function setStatus($status): static
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
@@ -834,7 +834,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\TransferDetail[]
      */
-    public function getTransferDetails()
+    public function getTransferDetails(): array
     {
         return $this->container['transfer_details'];
     }
@@ -846,7 +846,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setTransferDetails($transfer_details)
+    public function setTransferDetails($transfer_details): static
     {
         $this->container['transfer_details'] = $transfer_details;
 
@@ -858,7 +858,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getTransferType()
+    public function getTransferType(): string
     {
         return $this->container['transfer_type'];
     }
@@ -870,7 +870,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setTransferType($transfer_type)
+    public function setTransferType($transfer_type): static
     {
         $allowedValues = $this->getTransferTypeAllowableValues();
         if (!in_array($transfer_type, $allowedValues, true)) {
@@ -891,7 +891,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Vehicle
      */
-    public function getVehicle()
+    public function getVehicle(): Vehicle
     {
         return $this->container['vehicle'];
     }
@@ -903,7 +903,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setVehicle($vehicle)
+    public function setVehicle($vehicle): static
     {
         $this->container['vehicle'] = $vehicle;
 
@@ -916,7 +916,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -928,7 +928,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -941,7 +941,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -957,7 +957,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TransferServiceBookingCancel.php
+++ b/lib/Model/TransferServiceBookingCancel.php
@@ -88,7 +88,7 @@ class TransferServiceBookingCancel implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -98,7 +98,7 @@ class TransferServiceBookingCancel implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -158,7 +158,7 @@ class TransferServiceBookingCancel implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -168,7 +168,7 @@ class TransferServiceBookingCancel implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -178,7 +178,7 @@ class TransferServiceBookingCancel implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -188,7 +188,7 @@ class TransferServiceBookingCancel implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -204,7 +204,7 @@ const TRANSFER_TYPE_SHARED = 'SHARED';
      *
      * @return string[]
      */
-    public function getStatusAllowableValues()
+    public function getStatusAllowableValues(): array
     {
         return [
             self::STATUS_CONFIRMED,
@@ -216,7 +216,7 @@ self::STATUS_MODIFIED,        ];
      *
      * @return string[]
      */
-    public function getTransferTypeAllowableValues()
+    public function getTransferTypeAllowableValues(): array
     {
         return [
             self::TRANSFER_TYPE__PRIVATE,
@@ -254,7 +254,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -304,7 +304,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -315,7 +315,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Category
      */
-    public function getCategory()
+    public function getCategory(): Category
     {
         return $this->container['category'];
     }
@@ -327,7 +327,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setCategory($category)
+    public function setCategory($category): static
     {
         $this->container['category'] = $category;
 
@@ -339,7 +339,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return int
      */
-    public function getFactsheetId()
+    public function getFactsheetId(): int
     {
         return $this->container['factsheet_id'];
     }
@@ -351,7 +351,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setFactsheetId($factsheet_id)
+    public function setFactsheetId($factsheet_id): static
     {
         $this->container['factsheet_id'] = $factsheet_id;
 
@@ -363,7 +363,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return int
      */
-    public function getId()
+    public function getId(): int
     {
         return $this->container['id'];
     }
@@ -375,7 +375,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->container['id'] = $id;
 
@@ -387,7 +387,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Pax[]
      */
-    public function getPaxes()
+    public function getPaxes(): array
     {
         return $this->container['paxes'];
     }
@@ -399,7 +399,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setPaxes($paxes)
+    public function setPaxes($paxes): static
     {
         $this->container['paxes'] = $paxes;
 
@@ -411,7 +411,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\PickupInformation
      */
-    public function getPickupInformation()
+    public function getPickupInformation(): PickupInformation
     {
         return $this->container['pickup_information'];
     }
@@ -423,7 +423,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setPickupInformation($pickup_information)
+    public function setPickupInformation($pickup_information): static
     {
         $this->container['pickup_information'] = $pickup_information;
 
@@ -435,7 +435,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Price
      */
-    public function getPrice()
+    public function getPrice(): Price
     {
         return $this->container['price'];
     }
@@ -447,7 +447,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setPrice($price)
+    public function setPrice($price): static
     {
         $this->container['price'] = $price;
 
@@ -459,7 +459,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getStatus()
+    public function getStatus(): string
     {
         return $this->container['status'];
     }
@@ -471,7 +471,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setStatus($status)
+    public function setStatus($status): static
     {
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
@@ -492,7 +492,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getTransferType()
+    public function getTransferType(): string
     {
         return $this->container['transfer_type'];
     }
@@ -504,7 +504,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setTransferType($transfer_type)
+    public function setTransferType($transfer_type): static
     {
         $allowedValues = $this->getTransferTypeAllowableValues();
         if (!in_array($transfer_type, $allowedValues, true)) {
@@ -525,7 +525,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Vehicle
      */
-    public function getVehicle()
+    public function getVehicle(): Vehicle
     {
         return $this->container['vehicle'];
     }
@@ -537,7 +537,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setVehicle($vehicle)
+    public function setVehicle($vehicle): static
     {
         $this->container['vehicle'] = $vehicle;
 
@@ -550,7 +550,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -562,7 +562,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -575,7 +575,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -591,7 +591,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TransferServiceBookingList.php
+++ b/lib/Model/TransferServiceBookingList.php
@@ -84,7 +84,7 @@ class TransferServiceBookingList implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -94,7 +94,7 @@ class TransferServiceBookingList implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -148,7 +148,7 @@ class TransferServiceBookingList implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -158,7 +158,7 @@ class TransferServiceBookingList implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -168,7 +168,7 @@ class TransferServiceBookingList implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -178,7 +178,7 @@ class TransferServiceBookingList implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -191,7 +191,7 @@ const TRANSFER_TYPE_SHARED = 'SHARED';
      *
      * @return string[]
      */
-    public function getTransferTypeAllowableValues()
+    public function getTransferTypeAllowableValues(): array
     {
         return [
             self::TRANSFER_TYPE__PRIVATE,
@@ -227,7 +227,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -269,7 +269,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -280,7 +280,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\CancellationPolicy[]
      */
-    public function getCancellationPolicies()
+    public function getCancellationPolicies(): array
     {
         return $this->container['cancellation_policies'];
     }
@@ -292,7 +292,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setCancellationPolicies($cancellation_policies)
+    public function setCancellationPolicies($cancellation_policies): static
     {
         $this->container['cancellation_policies'] = $cancellation_policies;
 
@@ -304,7 +304,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Category
      */
-    public function getCategory()
+    public function getCategory(): Category
     {
         return $this->container['category'];
     }
@@ -316,7 +316,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setCategory($category)
+    public function setCategory($category): static
     {
         $this->container['category'] = $category;
 
@@ -328,7 +328,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Link[]
      */
-    public function getLinks()
+    public function getLinks(): array
     {
         return $this->container['links'];
     }
@@ -340,7 +340,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setLinks($links)
+    public function setLinks($links): static
     {
         $this->container['links'] = $links;
 
@@ -352,7 +352,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\PickupInformation
      */
-    public function getPickupInformation()
+    public function getPickupInformation(): PickupInformation
     {
         return $this->container['pickup_information'];
     }
@@ -364,7 +364,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setPickupInformation($pickup_information)
+    public function setPickupInformation($pickup_information): static
     {
         $this->container['pickup_information'] = $pickup_information;
 
@@ -376,7 +376,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Price
      */
-    public function getPrice()
+    public function getPrice(): Price
     {
         return $this->container['price'];
     }
@@ -388,7 +388,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setPrice($price)
+    public function setPrice($price): static
     {
         $this->container['price'] = $price;
 
@@ -400,7 +400,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return string
      */
-    public function getTransferType()
+    public function getTransferType(): string
     {
         return $this->container['transfer_type'];
     }
@@ -412,7 +412,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setTransferType($transfer_type)
+    public function setTransferType($transfer_type): static
     {
         $allowedValues = $this->getTransferTypeAllowableValues();
         if (!in_array($transfer_type, $allowedValues, true)) {
@@ -433,7 +433,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return \Swagger\Client\Model\Vehicle
      */
-    public function getVehicle()
+    public function getVehicle(): Vehicle
     {
         return $this->container['vehicle'];
     }
@@ -445,7 +445,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return $this
      */
-    public function setVehicle($vehicle)
+    public function setVehicle($vehicle): static
     {
         $this->container['vehicle'] = $vehicle;
 
@@ -458,7 +458,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -470,7 +470,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -483,7 +483,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -499,7 +499,7 @@ self::TRANSFER_TYPE_SHARED,        ];
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TransferServiceContent.php
+++ b/lib/Model/TransferServiceContent.php
@@ -84,7 +84,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -94,7 +94,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -148,7 +148,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -158,7 +158,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -168,7 +168,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -178,7 +178,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -214,7 +214,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -245,7 +245,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -256,7 +256,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Category
      */
-    public function getCategory()
+    public function getCategory(): Category
     {
         return $this->container['category'];
     }
@@ -268,7 +268,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCategory($category)
+    public function setCategory($category): static
     {
         $this->container['category'] = $category;
 
@@ -280,7 +280,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferTimeInfo[]
      */
-    public function getCustomerTransferTimeInfo()
+    public function getCustomerTransferTimeInfo(): array
     {
         return $this->container['customer_transfer_time_info'];
     }
@@ -292,7 +292,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCustomerTransferTimeInfo($customer_transfer_time_info)
+    public function setCustomerTransferTimeInfo($customer_transfer_time_info): static
     {
         $this->container['customer_transfer_time_info'] = $customer_transfer_time_info;
 
@@ -304,7 +304,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Image[]
      */
-    public function getImages()
+    public function getImages(): array
     {
         return $this->container['images'];
     }
@@ -316,7 +316,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setImages($images)
+    public function setImages($images): static
     {
         $this->container['images'] = $images;
 
@@ -328,7 +328,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferTimeInfo[]
      */
-    public function getSupplierTransferTimeInfo()
+    public function getSupplierTransferTimeInfo(): array
     {
         return $this->container['supplier_transfer_time_info'];
     }
@@ -340,7 +340,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setSupplierTransferTimeInfo($supplier_transfer_time_info)
+    public function setSupplierTransferTimeInfo($supplier_transfer_time_info): static
     {
         $this->container['supplier_transfer_time_info'] = $supplier_transfer_time_info;
 
@@ -352,7 +352,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferDetailInfo[]
      */
-    public function getTransferDetailInfo()
+    public function getTransferDetailInfo(): array
     {
         return $this->container['transfer_detail_info'];
     }
@@ -364,7 +364,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTransferDetailInfo($transfer_detail_info)
+    public function setTransferDetailInfo($transfer_detail_info): static
     {
         $this->container['transfer_detail_info'] = $transfer_detail_info;
 
@@ -376,7 +376,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\TransferRemarks[]
      */
-    public function getTransferRemarks()
+    public function getTransferRemarks(): array
     {
         return $this->container['transfer_remarks'];
     }
@@ -388,7 +388,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setTransferRemarks($transfer_remarks)
+    public function setTransferRemarks($transfer_remarks): static
     {
         $this->container['transfer_remarks'] = $transfer_remarks;
 
@@ -400,7 +400,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return \Swagger\Client\Model\Vehicle
      */
-    public function getVehicle()
+    public function getVehicle(): Vehicle
     {
         return $this->container['vehicle'];
     }
@@ -412,7 +412,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setVehicle($vehicle)
+    public function setVehicle($vehicle): static
     {
         $this->container['vehicle'] = $vehicle;
 
@@ -425,7 +425,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -437,7 +437,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -450,7 +450,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -466,7 +466,7 @@ class TransferServiceContent implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/TransferTimeInfo.php
+++ b/lib/Model/TransferTimeInfo.php
@@ -76,7 +76,7 @@ class TransferTimeInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -86,7 +86,7 @@ class TransferTimeInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -128,7 +128,7 @@ class TransferTimeInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -138,7 +138,7 @@ class TransferTimeInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -148,7 +148,7 @@ class TransferTimeInfo implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -158,7 +158,7 @@ class TransferTimeInfo implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -172,7 +172,7 @@ const TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL = 'SUPPLIER_MAX_WAITING_TIME_
      *
      * @return string[]
      */
-    public function getTypeAllowableValues()
+    public function getTypeAllowableValues(): array
     {
         return [
             self::TYPE_CUSTOMER_MAX_WAITING_TIME,
@@ -205,7 +205,7 @@ self::TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL,        ];
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -235,7 +235,7 @@ self::TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL,        ];
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -246,7 +246,7 @@ self::TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL,        ];
      *
      * @return string
      */
-    public function getMetric()
+    public function getMetric(): string
     {
         return $this->container['metric'];
     }
@@ -258,7 +258,7 @@ self::TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL,        ];
      *
      * @return $this
      */
-    public function setMetric($metric)
+    public function setMetric($metric): static
     {
         $this->container['metric'] = $metric;
 
@@ -270,7 +270,7 @@ self::TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL,        ];
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->container['type'];
     }
@@ -282,7 +282,7 @@ self::TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL,        ];
      *
      * @return $this
      */
-    public function setType($type)
+    public function setType($type): static
     {
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($type, $allowedValues, true)) {
@@ -303,7 +303,7 @@ self::TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL,        ];
      *
      * @return int
      */
-    public function getValue()
+    public function getValue(): int
     {
         return $this->container['value'];
     }
@@ -315,7 +315,7 @@ self::TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL,        ];
      *
      * @return $this
      */
-    public function setValue($value)
+    public function setValue($value): static
     {
         $this->container['value'] = $value;
 
@@ -328,7 +328,7 @@ self::TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL,        ];
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -340,7 +340,7 @@ self::TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL,        ];
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -353,7 +353,7 @@ self::TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL,        ];
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -369,7 +369,7 @@ self::TYPE_SUPPLIER_MAX_WAITING_TIME_INTERNATIONAL,        ];
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/Vehicle.php
+++ b/lib/Model/Vehicle.php
@@ -74,7 +74,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerTypes()
+    public static function swaggerTypes(): array
     {
         return self::$swaggerTypes;
     }
@@ -84,7 +84,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function swaggerFormats()
+    public static function swaggerFormats(): array
     {
         return self::$swaggerFormats;
     }
@@ -123,7 +123,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -133,7 +133,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -143,7 +143,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return array
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -153,7 +153,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$swaggerModelName;
     }
@@ -184,7 +184,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -200,7 +200,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -211,7 +211,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->container['code'];
     }
@@ -223,7 +223,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setCode($code)
+    public function setCode($code): static
     {
         $this->container['code'] = $code;
 
@@ -235,7 +235,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->container['name'];
     }
@@ -247,7 +247,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName($name): static
     {
         $this->container['name'] = $name;
 
@@ -260,7 +260,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -272,7 +272,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -285,7 +285,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -301,7 +301,7 @@ class Vehicle implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }

--- a/lib/ObjectSerializer.php
+++ b/lib/ObjectSerializer.php
@@ -43,10 +43,8 @@ class ObjectSerializer
      *
      * @param mixed  $data   the data to serialize
      * @param string $format the format of the Swagger type of the data
-     *
-     * @return string|object serialized form of $data
      */
-    public static function sanitizeForSerialization($data, $format = null): float|object|bool|int|string|null
+    public static function sanitizeForSerialization($data, $format = null): mixed
     {
         if (is_scalar($data) || null === $data) {
             return $data;
@@ -226,7 +224,7 @@ class ObjectSerializer
      *
      * @return object|array|null an single or an array of $class instances
      */
-    public static function deserialize($data, $class, $httpHeaders = null): object|\DateTime|array|\SplFileObject|null
+    public static function deserialize($data, $class, $httpHeaders = null): object|array|null
     {
         if (null === $data) {
             return null;

--- a/lib/ObjectSerializer.php
+++ b/lib/ObjectSerializer.php
@@ -46,7 +46,7 @@ class ObjectSerializer
      *
      * @return string|object serialized form of $data
      */
-    public static function sanitizeForSerialization($data, $format = null)
+    public static function sanitizeForSerialization($data, $format = null): float|object|bool|int|string|null
     {
         if (is_scalar($data) || null === $data) {
             return $data;
@@ -88,7 +88,7 @@ class ObjectSerializer
      *
      * @return string the sanitized filename
      */
-    public static function sanitizeFilename($filename)
+    public static function sanitizeFilename($filename): string
     {
         if (preg_match("/.*[\/\\\\](.*)$/", $filename, $match)) {
             return $match[1];
@@ -105,7 +105,7 @@ class ObjectSerializer
      *
      * @return string the serialized object
      */
-    public static function toPathValue($value)
+    public static function toPathValue($value): string
     {
         return rawurlencode(self::toString($value));
     }
@@ -121,7 +121,7 @@ class ObjectSerializer
      *
      * @return string the serialized object
      */
-    public static function toQueryValue($object, $format = null)
+    public static function toQueryValue($object, $format = null): \DateTime|string
     {
         if (is_array($object)) {
             return implode(',', $object);
@@ -139,7 +139,7 @@ class ObjectSerializer
      *
      * @return string the header string
      */
-    public static function toHeaderValue($value)
+    public static function toHeaderValue($value): \DateTime|string
     {
         return self::toString($value);
     }
@@ -153,7 +153,7 @@ class ObjectSerializer
      *
      * @return string the form string
      */
-    public static function toFormValue($value)
+    public static function toFormValue($value): \DateTime|string
     {
         if ($value instanceof \SplFileObject) {
             return $value->getRealPath();
@@ -173,7 +173,7 @@ class ObjectSerializer
      *
      * @return string the header string
      */
-    public static function toString($value, $format = null)
+    public static function toString($value, $format = null): \DateTime|string
     {
         if ($value instanceof \DateTime) {
             return ($format === 'date') ? $value->format('Y-m-d') : $value->format(\DateTime::ATOM);
@@ -192,7 +192,7 @@ class ObjectSerializer
      *
      * @return string
      */
-    public static function serializeCollection(array $collection, $collectionFormat, $allowCollectionFormatMulti = false)
+    public static function serializeCollection(array $collection, $collectionFormat, $allowCollectionFormatMulti = false): string
     {
         if ($allowCollectionFormatMulti && ('multi' === $collectionFormat)) {
             // http_build_query() almost does the job for us. We just
@@ -226,7 +226,7 @@ class ObjectSerializer
      *
      * @return object|array|null an single or an array of $class instances
      */
-    public static function deserialize($data, $class, $httpHeaders = null)
+    public static function deserialize($data, $class, $httpHeaders = null): object|\DateTime|array|\SplFileObject|null
     {
         if (null === $data) {
             return null;


### PR DESCRIPTION
In php 8.1 the return-type is required when extending a method that have an return type.

Executed phpstorm inspection for adding return types, and then adjusted 2 of them manually.